### PR TITLE
Fixed wrong formatting in JSON object

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Use the `solcx.compile_standard` function to make use of the [standard-json](htt
 }
 >>> compile_standard({
 ...     'language': 'Solidity',
-...     'sources': {'Foo.sol': 'urls': ["/path/to/my/sources/Foo.sol"]},
+...     'sources': {'Foo.sol': {'urls': ["/path/to/my/sources/Foo.sol"]}},
 ... }, allow_paths="/path/to/my/sources")
 {
     'contracts': {...},


### PR DESCRIPTION
### What was wrong?

```
'sources': {'Foo.sol': 'urls': ["/path/to/my/sources/Foo.sol"]},
```
is not valid JSON syntax, as there is a missing bracket before `urls`.

### How was it fixed?

Added the missing brackets.

#### Cute Animal Picture

> put a cute animal picture here.
