### PR TITLE
Return empty string when no previous installation of solc is identified

### DIFF
--- a/solcx/install.py
+++ b/solcx/install.py
@@ -26,7 +26,7 @@ def get_solc_folder():
 
 def import_installed_solc():
     if sys.platform.startswith('linux'):
-        path_list = [subprocess.check_output(['which','solc']).decode().strip()]
+        path_list = [subprocess.run(['which', 'solc'], capture_output=True).stdout.decode().strip()]
         if not path_list[0]:
             return
     elif sys.platform == 'darwin':


### PR DESCRIPTION
### What was wrong?
The check_output implementation for checking existing solc versions raises an error when no solc version is found. 

### How was it fixed?
Switch from "check_output" to "run" without the check=True argument present. This returns en empty string when solc is not found on the system.

#### Cute Animal Picture

![alt cute animal picture](https://i.redd.it/pzrc9zdobqr21.png )