### PR TITLE
Add range set/install functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,20 @@ Or via the command line:
 $ python -m solcx.install v0.4.25
 ```
 
+You can install the highest compatible version based on the pragma version string:
+
+```python
+>>> from solcx import install_solc_pragma
+>>> install_solc_pragma('^0.4.20 || >0.5.5 <0.7.0')
+```
+
+Or you can set the version based on the pragma version string.  This will use the highest compatible version installed, if you have a compatible version installed, or it will install the highest compatible version:
+
+```python
+>>> from solcx import set_solc_version_pragma
+>>> set_solc_version_pragma('^0.4.20 || >0.5.5 <0.7.0')
+```
+
 You can also view available versions or change the active version of solc:
 
 ```python
@@ -40,7 +54,7 @@ You can also view available versions or change the active version of solc:
 >>> get_installed_solc_versions()
 ['v0.4.25', 'v0.5.3']
 
->>> set_solc_version('v0.4.25)
+>>> set_solc_version('v0.4.25')
 ```
 
 ## Standard JSON Compilation

--- a/solcx/__init__.py
+++ b/solcx/__init__.py
@@ -13,9 +13,11 @@ from .main import (  # noqa: F401
 from .install import (
     import_installed_solc,
     install_solc,
+    install_solc_pragma,
     get_installed_solc_versions,
     get_solc_folder,
-    set_solc_version
+    set_solc_version,
+    set_solc_version_pragma
 )
 
 # check for installed version of solc

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -73,7 +73,7 @@ def set_solc_version_pragma(version):
             comparator_set_flag = True
             for comparator in comparators:
                 operator = comparator['operator']
-                if not _compare_versions(installed_version[1:], comparator['version'], operator):
+                if not _compare_versions(installed_version, comparator['version'], operator):
                     comparator_set_flag = False
             if comparator_set_flag:
                 range_flag = True
@@ -119,13 +119,12 @@ def install_solc_pragma(version, install=True):
     versions_json = requests.get(ALL_RELEASES).json()
     range_flag = False
     for version_json in versions_json:
-        v = version_json['tag_name'][1:]
         for comparator_set in comparator_set_range:
             comparators = [m.groupdict() for m in comparator_regex.finditer(comparator_set)]
             comparator_set_flag = True
             for comparator in comparators:
                 operator = comparator['operator']
-                if not _compare_versions(v, comparator['version'], operator):
+                if not _compare_versions(version_json['tag_name'], comparator['version'], operator):
                     comparator_set_flag = False
             if comparator_set_flag:
                 range_flag = True
@@ -137,6 +136,8 @@ def install_solc_pragma(version, install=True):
     raise ValueError("Compatible solc version does not exist")
 
 def _compare_versions(v1, v2, operator='='):
+    v1 = v1.lstrip('v')
+    v2 = v2.lstrip('v')
     v1_split = [int(i) for i in v1.split('.')]
     v2_split = [int(i) for i in v2.split('.')]
     if operator == '' or operator == None:

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -152,10 +152,10 @@ def _compare_versions(v1, v2, operator='='):
         if v1_split[0] > v2_split[0] or (v1_split[0] == v2_split[0] and (v1_split[1] > v2_split[1] or (v1_split[1] == v2_split[1] and v1_split[2] > v2_split[2]))):
             return True
     elif operator == '<=':
-        if v1_split[0] > v2_split[0] or (v1_split[0] == v2_split[0] and (v1_split[1] > v2_split[1] or (v1_split[1] == v2_split[1] and v1_split[2] <= v2_split[2]))):
+        if v1_split[0] < v2_split[0] or (v1_split[0] == v2_split[0] and (v1_split[1] < v2_split[1] or (v1_split[1] == v2_split[1] and v1_split[2] <= v2_split[2]))):
             return True
     elif operator == '<':
-        if v1_split[0] > v2_split[0] or (v1_split[0] == v2_split[0] and (v1_split[1] > v2_split[1] or (v1_split[1] == v2_split[1] and v1_split[2] < v2_split[2]))):
+        if v1_split[0] < v2_split[0] or (v1_split[0] == v2_split[0] and (v1_split[1] < v2_split[1] or (v1_split[1] == v2_split[1] and v1_split[2] < v2_split[2]))):
             return True
     elif operator == '^':
         if v1_split[0] == v2_split[0] and v1_split[1] == v2_split[1] and v1_split[2] >= v2_split[2]:

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -77,6 +77,32 @@ def set_solc_version_range(max_version=None, min_version='v0.4.11'):
     global solc_version
     solc_version = version
 
+def set_solc_version_pragma(version):
+    version = version.strip()
+    comparator_set_range = [i.strip() for i in version.split('||')]
+    installed_versions = get_installed_solc_versions()
+    comparator_regex = re.compile(r'(?P<operator>([<>]?=?|\^))(?P<version>(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+))')
+    range_flag = False
+    set_version = None
+    for installed_version in reversed(installed_versions):
+        for comparator_set in comparator_set_range:
+            comparators = comparator_regex.findall(version)
+            comparator_set_flag = True
+            for comparator in comparators:
+                operator = comparator.group('operator')
+                if not _compare_versions(installed_version, comparator.group('version'), operator):
+                    comparator_set_flag = False
+            if comparator_set_flag:
+                range_flag = True
+        if range_flag:
+            set_version = installed_version
+            break
+    if not set_version:
+        set_version = install_solc_pragma(version)
+    global solc_version
+    solc_version = set_version
+
+
 
 def get_installed_solc_versions():
     return sorted(i.name[5:] for i in get_solc_folder().glob('solc-v*'))
@@ -112,6 +138,12 @@ def install_solc_range(max_version=None, min_version='v0.4.11'):
                 install_solc(version['tag_name'])
                 return version['tag_name']
     raise ValueError("solc version does not exist")
+
+def install_solc_pragma(version):
+    return
+
+def _compare_versions(v1, v2, operator='='):
+    return
 
 
 def _check_version(version):

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -133,6 +133,8 @@ def install_solc_pragma(version):
 def _compare_versions(v1, v2, operator='='):
     v1_split = [int(i) for i in v1.split('.')]
     v2_split = [int(i) for i in v2.split('.')]
+    if operator == '' or operator == None:
+        operator = '='
     if operator == '=':
         if v1_split[0] == v2_split[0] and v1_split[1] == v2_split[1] and v1_split[2] == v2_split[2]:
             return True

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -114,7 +114,7 @@ def install_solc_pragma(version):
     versions_json = requests.get(ALL_RELEASES).json()
     range_flag = False
     for version_json in versions_json:
-        v = [int(i) for i in version_json['tag_name'][1:].split('.')]
+        v = version_json['tag_name'][1:]
         for comparator_set in comparator_set_range:
             comparators = [m.groupdict() for m in comparator_regex.finditer(comparator_set)]
             comparator_set_flag = True

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -68,11 +68,11 @@ def set_solc_version_pragma(version):
     set_version = None
     for installed_version in reversed(installed_versions):
         for comparator_set in comparator_set_range:
-            comparators = comparator_regex.findall(comparator_set)
+            comparators = [m.groupdict() for m in comparator_regex.finditer(comparator_set)]
             comparator_set_flag = True
             for comparator in comparators:
-                operator = comparator.group('operator')
-                if not _compare_versions(installed_version, comparator.group('version'), operator):
+                operator = comparator['operator']
+                if not _compare_versions(installed_version, comparator['version'], operator):
                     comparator_set_flag = False
             if comparator_set_flag:
                 range_flag = True
@@ -116,11 +116,11 @@ def install_solc_pragma(version):
     for version_json in versions_json:
         v = [int(i) for i in version_json['tag_name'][1:].split('.')]
         for comparator_set in comparator_set_range:
-            comparators = comparator_regex.findall(comparator_set)
+            comparators = [m.groupdict() for m in comparator_regex.finditer(comparator_set)]
             comparator_set_flag = True
             for comparator in comparators:
-                operator = comparator.group('operator')
-                if not _compare_versions(v, comparator.group('version'), operator):
+                operator = comparator['operator']
+                if not _compare_versions(v, comparator['version'], operator):
                     comparator_set_flag = False
             if comparator_set_flag:
                 range_flag = True

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -14,6 +14,7 @@ import zipfile
 
 DOWNLOAD_BASE = "https://github.com/ethereum/solidity/releases/download/{}/{}"
 API = "https://api.github.com/repos/ethereum/solidity/releases/latest"
+ALL_RELEASES = "https://api.github.com/repos/ethereum/solidity/releases"
 
 solc_version = None
 
@@ -57,6 +58,25 @@ def set_solc_version(version=None):
     global solc_version
     solc_version = version
 
+def set_solc_version_range(max_version=None, min_version='v0.4.11'):
+    max_version = _check_version(max_version)
+    min_version = _check_version(min_version)
+    vmin = [int(i) for i in min_version[1:].split('.')]
+    vmax = [int(i) for i in max_version[1:].split('.')]
+    if vmin[0] > vmax[0] or (vmin[0] == vmax[0] and (vmin[1] > vmax[1] or (vmin[1] == vmax[1] and vmin[2] > vmax[2]))):
+        raise ValueError("max solc version must be higher than or equal to min solc version")
+    installed_versions = get_installed_solc_versions()
+    version = None
+    for installed_version in reversed(installed_versions):
+        vins = [int(i) for i in installed_version[1:].split('.')]
+        if vins[0] < vmax[0] or (vins[0] == vmax[0] and (vins[1] < vmax[1] or (vins[1] == vmax[1] and vins[2] <= vmax[2]))):
+            if vmin[0] < vins[0] or (vmin[0] == vins[0] and (vmin[1] < vins[1] or (vmin[1] == vins[1] and vmin[2] <= vins[2]))):
+                version = installed_version
+    if not version:
+        version = install_solc_range(max_version, min_version)
+    global solc_version
+    solc_version = version
+
 
 def get_installed_solc_versions():
     return sorted(i.name[5:] for i in get_solc_folder().glob('solc-v*'))
@@ -78,6 +98,20 @@ def install_solc(version=None):
         message="Checking installed executable version @ {}".format(binary_path)
     )
     print("solc {} successfully installed at: {}".format(version, binary_path))
+
+def install_solc_range(max_version=None, min_version='v0.4.11'):
+    max_version = _check_version(max_version)
+    min_version = _check_version(min_version)
+    vmin = [int(i) for i in min_version[1:].split('.')]
+    vmax = [int(i) for i in max_version[1:].split('.')]
+    versions_json = requests.get(ALL_RELEASES).json()
+    for version in versions_json:
+        v = [int(i) for i in version['tag_name'][1:].split('.')]
+        if v[0] < vmax[0] or (v[0] == vmax[0] and (v[1] < vmax[1] or (v[1] == vmax[1] and v[2] <= vmax[2]))):
+            if vmin[0] < v[0] or (vmin[0] == v[0] and (vmin[1] < v[1] or (vmin[1] == v[1] and vmin[2] <= v[2]))):
+                install_solc(version['tag_name'])
+                return version['tag_name']
+    raise ValueError("solc version does not exist")
 
 
 def _check_version(version):

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -72,7 +72,7 @@ def set_solc_version_pragma(version):
             comparator_set_flag = True
             for comparator in comparators:
                 operator = comparator['operator']
-                if not _compare_versions(installed_version, comparator['version'], operator):
+                if not _compare_versions(installed_version[1:], comparator['version'], operator):
                     comparator_set_flag = False
             if comparator_set_flag:
                 range_flag = True

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -58,6 +58,7 @@ def set_solc_version(version=None):
         install_solc(version)
     global solc_version
     solc_version = version
+    print("Using solc version {}".format(solc_version))
 
 def set_solc_version_pragma(version):
     version = version.strip()
@@ -78,11 +79,15 @@ def set_solc_version_pragma(version):
                 range_flag = True
         if range_flag:
             set_version = installed_version
+            newer_version = install_solc_pragma(version, install=False)
+            if _compare_versions(set_version, newer_version, '<'):
+                print("Newer compatible solc version exists: {}".format(newer_version))
             break
     if not set_version:
         set_version = install_solc_pragma(version)
     global solc_version
     solc_version = set_version
+    print("Using solc version {}".format(solc_version))
 
 
 
@@ -107,7 +112,7 @@ def install_solc(version=None):
     )
     print("solc {} successfully installed at: {}".format(version, binary_path))
 
-def install_solc_pragma(version):
+def install_solc_pragma(version, install=True):
     version = version.strip()
     comparator_set_range = [i.strip() for i in version.split('||')]
     comparator_regex = re.compile(r'(?P<operator>([<>]?=?|\^))(?P<version>(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+))')
@@ -126,9 +131,10 @@ def install_solc_pragma(version):
                 range_flag = True
         if range_flag:
             _check_version(version_json['tag_name'])
-            install_solc(version_json['tag_name'])
+            if install:
+                install_solc(version_json['tag_name'])
             return version_json['tag_name']
-    raise ValueError("compatible solc version does not exist")
+    raise ValueError("Compatible solc version does not exist")
 
 def _compare_versions(v1, v2, operator='='):
     v1_split = [int(i) for i in v1.split('.')]


### PR DESCRIPTION
### What was wrong?

Solc version could not be set or installed from a range of versions
### How was it fixed?

The highest compatible solc version is set based on a string with syntax matching that of the pragma version line in a solidity contract.  If none exist, the highest compatible version is installed and set.
#### Cute animal picture

![alt-cute-animal-picture](https://i.imgur.com/dEmWoGk.jpg)