### PR TITLE
v0.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ develop-eggs
 .installed.cfg
 lib
 lib64
+venv
 
 # Installer logs
 pip-log.txt

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+0.4.0
+-----
+
+ - Install new versions into solcx/temp - prevents issues with aborted installs
+ - set_solc_version raises instead of installing when version is uninstalled
+ - Do not allow version=None on installer methods
+
 0.3.0
 -----
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@
 -----
 
  - Install new versions into solcx/temp - prevents issues with aborted installs
- - set_solc_version raises instead of installing when version is uninstalled
+ - set_solc_version raises instead of installing when requested version is not installed
  - Do not allow version=None on installer methods
 
 0.3.0

--- a/README.md
+++ b/README.md
@@ -20,9 +20,7 @@ pip install py-solc-x
 
 ## Installing the `solc` Executable
 
-The first time py-solc-x is imported it will automatically check for an installed version of solc on your system. If none is found, it will install the most recently released version that is compatible with your operating system.
-
-If you wish to install a different version you may do so from within python:
+The first time py-solc-x is imported it will automatically check for an installed version of solc on your system. If none is found, you must manually install via `solcx.install_solc`
 
 ```python
 >>> from solcx import install_solc
@@ -33,6 +31,16 @@ Or via the command line:
 
 ```bash
 $ python -m solcx.install v0.4.25
+```
+
+Py-solc-x defaults to the most recent installed version set as the active one. To check or modify the active version:
+
+```python
+>>> from solcx import get_solc_version, set_solc_version
+>>> get_solc_version()
+Version('0.5.7+commit.6da8b019.Linux.gpp')
+>>> set_solc_version('v0.4.25')
+>>>
 ```
 
 To install the highest compatible version based on the pragma version string:
@@ -52,21 +60,11 @@ To set the version based on the pragma version string - this will use the highes
 To view available and installed versions:
 
 ```python
->>> from solcx import get_installed_solc_versions, set_solc_version
+>>> from solcx import get_installed_solc_versions, get_available_solc_versions
 >>> get_installed_solc_versions()
 ['v0.4.25', 'v0.5.3']
 >>> get_available_solc_versions()
 ['v0.5.8', 'v0.5.7', 'v0.5.6', 'v0.5.5', 'v0.5.4', 'v0.5.3', 'v0.5.2', 'v0.5.1', 'v0.5.0', 'v0.4.25', 'v0.4.24', 'v0.4.23', 'v0.4.22', 'v0.4.21', 'v0.4.20', 'v0.4.19', 'v0.4.18', 'v0.4.17', 'v0.4.16', 'v0.4.15', 'v0.4.14', 'v0.4.13', 'v0.4.12', 'v0.4.11']
-```
-
-To check or modify the active version:
-
-```python
->>> from solcx import get_solc_version, set_solc_version
->>> solcx.get_solc_version()
-Version('0.5.7+commit.6da8b019.Linux.gpp')
->>> set_solc_version('v0.4.25')
->>>
 ```
 
 ## Standard JSON Compilation

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import (
 
 setup(
     name='py-solc-x',
-    version='0.3.0',
+    version='0.4.0',
     description="""Python wrapper around the solc binary with 0.5.x support""",
     long_description_markdown_filename='README.md',
     author='Benjamin Hauser (forked from py-solc by Piper Merriam)',

--- a/solcx/__init__.py
+++ b/solcx/__init__.py
@@ -22,10 +22,6 @@ from .install import (
 # check for installed version of solc
 import_installed_solc()
 
-# if no installed version, download
-if not get_installed_solc_versions():
-    print("Cannot find solc, installing...")
-    install_solc()
-
 # default to latest version
-set_solc_version(get_installed_solc_versions()[-1])
+if get_installed_solc_versions():
+    set_solc_version(get_installed_solc_versions()[-1])

--- a/solcx/exceptions.py
+++ b/solcx/exceptions.py
@@ -40,3 +40,7 @@ class SolcError(Exception):
 
 class ContractsNotFound(SolcError):
     message = "No contracts found during compilation"
+
+
+class SolcNotInstalled(Exception):
+    pass

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -277,6 +277,7 @@ def _install_solc_linux(version):
     if binary_path:
         temp_path = _get_temp_folder().joinpath("solc-binary")
         _wget(download, temp_path)
+        temp_path.rename(binary_path)
         _chmod_plus_x(binary_path)
 
 

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -246,26 +246,36 @@ def _wget(url, path):
         raise
 
 
+def _check_for_installed_version(version):
+    path = get_solc_folder().joinpath("solc-" + version)
+    if path.exists():
+        print("solc {} already installed at: {}".format(version, path))
+        return False
+    return path
+
+
+def _get_temp_folder():
+    path = Path(__file__).parent.joinpath('temp')
+    path.mkdir(exist_ok=True)
+    return path
+
+
 def _install_solc_linux(version):
     download = DOWNLOAD_BASE.format(version, "solc-static-linux")
-    binary_path = get_solc_folder().joinpath("solc-" + version)
-    if binary_path.exists():
-        print("solc {} already installed at: {}".format(version, binary_path))
-        return
-    _wget(download, binary_path)
-    _chmod_plus_x(binary_path)
+    binary_path = _check_for_installed_version(version)
+    if not binary_path:
+        _wget(download, binary_path)
+        _chmod_plus_x(binary_path)
 
 
 def _install_solc_windows(version):
     download = DOWNLOAD_BASE.format(version, "solidity-windows.zip")
-    install_folder = get_solc_folder().joinpath("solc-" + version)
-    if install_folder.exists():
-        print("solc {} already installed at: {}".format(version, install_folder))
-        return
-    print("Downloading solc {} from {}".format(version, download))
-    request = requests.get(download)
-    with zipfile.ZipFile(BytesIO(request.content)) as zf:
-        zf.extractall(str(install_folder))
+    install_folder = check_for_installed_version(version)
+    if install_folder:
+        print("Downloading solc {} from {}".format(version, download))
+        request = requests.get(download)
+        with zipfile.ZipFile(BytesIO(request.content)) as zf:
+            zf.extractall(str(install_folder))
 
 
 def _install_solc_osx(version):
@@ -277,10 +287,8 @@ def _install_solc_osx(version):
     tar_path = get_solc_folder().joinpath("solc-{}.tar.gz".format(version))
     source_folder = get_solc_folder().joinpath("solidity_" + version[1:])
     download = DOWNLOAD_BASE.format(version, "solidity_{}.tar.gz".format(version[1:]))
-    binary_path = get_solc_folder().joinpath("solc-" + version)
-
-    if binary_path.exists():
-        print("solc {} already installed at: {}".format(version, binary_path))
+    binary_path = _check_for_installed_version(version)
+    if not binary_path:
         return
 
     _wget(download, tar_path)

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -166,6 +166,8 @@ def install_solc(version):
         [binary_path, '--version'],
         message="Checking installed executable version @ {}".format(binary_path)
     )
+    if not solc_version:
+        set_solc_version(version)
     print("solc {} successfully installed at: {}".format(version, binary_path))
 
 

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -297,25 +297,23 @@ def _install_solc_windows(version):
 
 
 def _install_solc_osx(version, allow):
-    if "v0.4" in version and not allow:
+    if version.startswith("v0.4") and not allow:
         raise ValueError(
-            "Py-solc-x cannot build solc versions 0.4.x on OSX. If you install solc 0.4.x\n"
-            "using brew and reload solcx, the installed version will be available.\n\n"
-            "See https://github.com/ethereum/homebrew-ethereum for installation instructions.\n"
-            "To ignore this error, include 'allow_osx=True' when calling solcx.yinstall_solc()"
+            "Py-solc-x cannot build solc versions 0.4.x on OSX. If you install solc 0.4.x "
+            "using brew and reload solcx, the installed version will be available. "
+            "See https://github.com/ethereum/homebrew-ethereum for installation instructions.\n\n"
+            "To ignore this error, include 'allow_osx=True' when calling solcx.install_solc()"
         )
     temp_path = _get_temp_folder().joinpath("solc-source.tar.gz".format(version))
     source_folder = _get_temp_folder().joinpath("solidity_" + version[1:])
     download = DOWNLOAD_BASE.format(version, "solidity_{}.tar.gz".format(version[1:]))
     binary_path = _check_for_installed_version(version)
-
     if not binary_path:
         return
 
     _wget(download, temp_path)
     with tarfile.open(str(temp_path), "r") as tar:
-        tar.extractall(str(get_solc_folder()))
-    temp_path.unlink()
+        tar.extractall(str(_get_temp_folder()))
 
     _check_subprocess_call(
         ["sh", str(source_folder.joinpath('scripts/install_deps.sh'))],
@@ -329,7 +327,6 @@ def _install_solc_osx(version, allow):
         for cmd in (["cmake", ".."], ["make"]):
             _check_subprocess_call(cmd, message="Running {}".format(cmd[0]))
         os.chdir(original_path)
-        binary_path = get_solc_folder().joinpath("solc-" + version)
         source_folder.joinpath('build/solc/solc').rename(binary_path)
     except subprocess.CalledProcessError as e:
         raise OSError(

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -152,13 +152,13 @@ def get_installed_solc_versions():
     return sorted(i.name[5:] for i in get_solc_folder().glob('solc-v*'))
 
 
-def install_solc(version):
+def install_solc(version, allow_osx=False):
     version = _check_version(version)
     platform = _get_platform()
     if platform == 'linux':
         _install_solc_linux(version)
     elif platform == 'darwin':
-        _install_solc_osx(version)
+        _install_solc_osx(version, allow_osx)
     elif platform == 'win32':
         _install_solc_windows(version)
     binary_path = get_executable(version)
@@ -296,12 +296,13 @@ def _install_solc_windows(version):
         temp_path.rename(install_folder)
 
 
-def _install_solc_osx(version):
-    if "v0.4" in version:
+def _install_solc_osx(version, allow):
+    if "v0.4" in version and not allow:
         raise ValueError(
             "Py-solc-x cannot build solc versions 0.4.x on OSX. If you install solc 0.4.x\n"
             "using brew and reload solcx, the installed version will be available.\n\n"
-            "See https://github.com/ethereum/homebrew-ethereum for installation instructions."
+            "See https://github.com/ethereum/homebrew-ethereum for installation instructions.\n"
+            "To ignore this error, include 'allow_osx=True' when calling solcx.yinstall_solc()"
         )
     temp_path = _get_temp_folder().joinpath("solc-source.tar.gz".format(version))
     source_folder = _get_temp_folder().joinpath("solidity_" + version[1:])


### PR DESCRIPTION
 - Install new versions into `solcx/temp` - prevents issues with aborted installs
 - `set_solc_version` raises instead of installing when requested version is not installed
 - Do not allow `version=None` on installer methods