### PR TITLE
V0.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,5 +37,10 @@ matrix:
       script: python -m pytest tests --cov=solcx
       after_success: python -m coveralls
 
+env:
+  global: COVERALLS_PARALLEL=true
+
+
 notifications:
   email: false
+  webhooks: https://coveralls.io/webhook

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,9 @@
-0.4.3 (unreleased)
+0.5.0 (unreleased)
 -----
 
  - Improved verbosity when get_available_solc_versions raises
+ - Remove interace flag (was removed from solc in 0.4.0)
+ - Raise on clone-bin and formal flags when using 0.5.x
 
 0.4.2
 -----

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+0.4.3 (unreleased)
+-----
+
+ - Improved verbosity when get_available_solc_versions raises
+
 0.4.2
 -----
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
-0.5.0 (unreleased)
+0.5.0
 -----
 
+ - Support for github API tokens via environment var GITHUB_TOKEN
  - Improved verbosity when get_available_solc_versions raises
  - Remove interace flag (was removed from solc in 0.4.0)
  - Raise on clone-bin and formal flags when using 0.5.x

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import (
 
 setup(
     name='py-solc-x',
-    version='0.4.2',
+    version='0.5.0',
     description="""Python wrapper around the solc binary with 0.5.x support""",
     long_description_markdown_filename='README.md',
     author='Ben Hauser (forked from py-solc by Piper Merriam)',

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -1,6 +1,7 @@
 """
 Install solc
 """
+from base64 import b64encode
 from io import BytesIO
 import os
 from pathlib import Path
@@ -144,14 +145,23 @@ def install_solc_pragma(pragma_string, install=True):
 def get_available_solc_versions(headers=None):
     versions = []
     pattern = VERSION_REGEX[_get_platform()]
+
+    # Github sometimes blocks CI from calling their API, if you are having issues try
+    # saving an API token to the environment variable GITHUB_TOKEN in your build environment
+    # https://github.blog/2013-05-16-personal-api-tokens/
+    if not headers and os.getenv('GITHUB_TOKEN'):
+        auth = b64encode(os.getenv('GITHUB_TOKEN').encode()).decode()
+        headers = {'Authorization': "Basic {}".format(auth)}
+
     data = requests.get(ALL_RELEASES, headers=headers)
     if data.status_code != 200:
         raise ConnectionError(
-            "{} when getting solc versions from Github: '{}'".format(
+            "Status {} when getting solc versions from Github: '{}'".format(
                 data.status_code,
                 data.json()['message']
             )
         )
+
     for release in data.json():
         asset = next((i for i in release['assets'] if re.match(pattern, i['name'])), False)
         if asset:

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -141,10 +141,18 @@ def install_solc_pragma(pragma_string, install=True):
     return version
 
 
-def get_available_solc_versions(headers={}):
+def get_available_solc_versions(headers=None):
     versions = []
     pattern = VERSION_REGEX[_get_platform()]
-    for release in requests.get(ALL_RELEASES, headers=headers).json():
+    data = requests.get(ALL_RELEASES, headers=headers)
+    if data.status_code != 200:
+        raise ConnectionError(
+            "{} when getting solc versions from Github: '{}'".format(
+                data.status_code,
+                data.json()['message']
+            )
+        )
+    for release in data.json():
         asset = next((i for i in release['assets'] if re.match(pattern, i['name'])), False)
         if asset:
             versions.append(release['tag_name'])

--- a/solcx/main.py
+++ b/solcx/main.py
@@ -82,7 +82,6 @@ ALL_OUTPUT_VALUES = (
     "bin-runtime",
     "clone-bin",
     "devdoc",
-    "interface",
     "opcodes",
     "userdoc",
 )

--- a/solcx/wrapper.py
+++ b/solcx/wrapper.py
@@ -38,7 +38,6 @@ def solc_wrapper(solc_binary=None,
                  bin_runtime=None,
                  clone_bin=None,
                  abi=None,
-                 interface=None,
                  hashes=None,
                  userdoc=None,
                  devdoc=None,
@@ -58,6 +57,7 @@ def solc_wrapper(solc_binary=None,
     if version:
         command.append('--version')
 
+    # removed in 0.4.21 and does nothing since <0.4.11, should be removed in the future
     if add_std:
         command.append('--add-std')
 
@@ -123,14 +123,8 @@ def solc_wrapper(solc_binary=None,
     if bin_runtime:
         command.append('--bin-runtime')
 
-    if clone_bin:
-        command.append('--clone-bin')
-
     if abi:
         command.append('--abi')
-
-    if interface:
-        command.append('--interface')
 
     if hashes:
         command.append('--hashes')
@@ -141,9 +135,6 @@ def solc_wrapper(solc_binary=None,
     if devdoc:
         command.append('--devdoc')
 
-    if formal:
-        command.append('--formal')
-
     if stdin is not None:
         # solc seems to expects utf-8 from stdin:
         # see Scanner class in Solidity source
@@ -151,6 +142,17 @@ def solc_wrapper(solc_binary=None,
 
     if evm_version:
         command.extend(('--evm-version', evm_version))
+
+    # only supported by 0.4.x versions
+    if clone_bin:
+        if "v0.5" in command[0]:
+            raise AttributeError(f"solc 0.5.x does not support the --clone-bin flag")
+        command.append('--clone-bin')
+
+    if formal:
+        if "v0.5" in command[0]:
+            raise AttributeError(f"solc 0.5.x does not support the --formal flag")
+        command.append('--formal')
 
     if (
         not standard_json and

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python3
 
-from base64 import b64encode
-import os
 import pytest
 import sys
 
@@ -10,9 +8,7 @@ import solcx
 if sys.platform == "darwin":
     VERSIONS = solcx.get_installed_solc_versions()
 else:
-    auth = b64encode(os.environ['GITAUTH'].encode()).decode('ascii')
-    headers = {'Authorization': f"Basic {auth}"}
-    VERSIONS = solcx.get_available_solc_versions(headers=headers)
+    VERSIONS = solcx.get_available_solc_versions()
 
 
 # auto-parametrize the all_versions fixture with all target solc versions

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,0 +1,46 @@
+#!/usr/bin/python3
+
+import pytest
+import sys
+
+import solcx
+from solcx.exceptions import SolcNotInstalled
+
+
+@pytest.fixture(autouse=True)
+def isolation():
+    p = sys.platform
+    v = solcx.install.solc_version
+    yield
+    sys.platform = p
+    solcx.install.solc_version = v
+
+
+def test_not_installed():
+    solcx.install.get_executable()
+    with pytest.raises(SolcNotInstalled):
+        solcx.install.get_executable('v0.4.0')
+    solcx.install.solc_version = None
+    with pytest.raises(SolcNotInstalled):
+        solcx.install.get_executable()
+
+
+def test_unsupported_version():
+    solcx.install._check_version('0.4.11')
+    with pytest.raises(ValueError):
+        solcx.install._check_version('0.4.10')
+
+
+def test_unknown_platform():
+    sys.platform = "potatoOS"
+    with pytest.raises(KeyError):
+        solcx.install_solc('0.5.0')
+
+
+@pytest.mark.skipif("sys.platform == 'win32'")
+def test_install_osx():
+    sys.platform = "darwin"
+    with pytest.raises(ValueError):
+        solcx.install_solc('0.4.25')
+    solcx.install_solc('0.4.25', allow_osx=True)
+    solcx.install_solc('0.5.4')

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1,0 +1,75 @@
+#!/usr/bin/python3
+
+import subprocess
+import pytest
+
+import solcx
+
+
+class PopenPatch:
+
+    def __init__(self):
+        self.proc = subprocess.Popen
+        self.args = []
+
+    def __call__(self, cmd, **kwargs):
+        assert cmd[0] == solcx.install.get_executable()
+        for i in self.args:
+            assert i in cmd
+        return self.proc(cmd, **kwargs)
+
+    def expect(self, *args):
+        self.args = [f"--{i.replace('_', '-')}" for i in args]
+
+
+@pytest.fixture
+def popen(monkeypatch):
+    p = PopenPatch()
+    monkeypatch.setattr('subprocess.Popen', p)
+    yield p
+
+
+@pytest.fixture(autouse=True)
+def all_(all_versions):
+    pass
+
+
+def test_help(popen):
+    popen.expect('help')
+    solcx.wrapper.solc_wrapper(help=True, success_return_code=1)
+
+
+def test_boolean_kwargs(popen, foo_source):
+    kwargs = [
+        'version', 'optimize', 'gas', 'ast', 'ast_json', 'asm', 'asm_json',
+        'opcodes', 'bin', 'bin_runtime', 'abi', 'hashes', 'userdoc', 'devdoc', 'standard_json'
+    ]
+    for value in kwargs:
+        popen.expect(value)
+        solcx.wrapper.solc_wrapper(stdin=foo_source, **{value: True})
+
+
+def test_solc4_only_kwargs(popen):
+    kwargs = ['clone_bin', 'formal']
+    if "0.5" in solcx.get_solc_version_string():
+        for value in kwargs:
+            popen.expect(value)
+            with pytest.raises(AttributeError):
+                solcx.wrapper.solc_wrapper(**{value: True})
+        return
+    for value in kwargs:
+        popen.expect(value)
+        solcx.wrapper.solc_wrapper(**{value: True})
+
+
+def test_value_kwargs(popen, foo_source):
+    kwargs = [
+        ('optimize_runs', 200),
+        ('libraries', "libraries:0x1234567890123456789012345678901234567890"),
+        ('output_dir', "."),
+        ('combined_json', "abi"),
+        ('allow_paths', ".")
+    ]
+    for value in kwargs:
+        popen.expect(value[0])
+        solcx.wrapper.solc_wrapper(stdin=foo_source, **{value[0]: value[1]})


### PR DESCRIPTION
 - Support for github API tokens via environment var ``GITHUB_TOKEN``
 - Improved verbosity when ``get_available_solc_versions`` raises
 - Remove interace flag (was removed from ``solc`` in ``0.4.0``)
 - Raise on ``clone-bin`` and ``formal`` flags when using ``0.5.x``
 - Test coverage at 82%