### PR TITLE
Upgrade semver package Spec to SimpleSpec

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     setup_requires=['setuptools-markdown'],
     python_requires='>=3.4, <4',
     install_requires=[
-        "semantic_version>=2.6.0",
+        "semantic_version>=2.8.1",
         "requests>=2.9.1"
     ],
     license="MIT",

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -7,7 +7,7 @@ import os
 from pathlib import Path
 import re
 import requests
-from semantic_version import Version, Spec
+from semantic_version import Version, SimpleSpec
 import shutil
 import stat
 import subprocess
@@ -177,7 +177,7 @@ def _select_pragma_version(pragma_string, version_list):
     version = None
 
     for comparator_set in comparator_set_range:
-        spec = Spec(*(i[0] for i in comparator_regex.findall(comparator_set)))
+        spec = SimpleSpec(*(i[0] for i in comparator_regex.findall(comparator_set)))
         selected = spec.select(version_list)
         if selected and (not version or version < selected):
             version = selected
@@ -210,7 +210,7 @@ def install_solc(version, allow_osx=False):
 
 def _check_version(version):
     version = Version(version.lstrip('v'))
-    if version not in Spec('>=0.4.11'):
+    if version not in SimpleSpec('>=0.4.11'):
         raise ValueError("py-solc-x does not support solc versions <0.4.11")
     return "v" + str(version)
 

--- a/solcx/main.py
+++ b/solcx/main.py
@@ -55,7 +55,7 @@ def get_solc_version(**kwargs):
 
 
 def solc_supports_standard_json_interface(**kwargs):
-    return get_solc_version() in semantic_version.Spec('>=0.4.11')
+    return get_solc_version() in semantic_version.SimpleSpec('>=0.4.11')
 
 
 def _parse_compiler_output(stdoutdata):


### PR DESCRIPTION
### What was wrong / missing?
`semantic_version` was throwing deprecation warnings about the `Spec` object being put out of order soon.

### How was it fixed / added?
Upgraded the package and replaced existing usages with the new `SimpleSpec` object.

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5565837/64288837-5b2e8c80-cf63-11e9-9e27-f1dbc701e68e.png)
