### PR TITLE
Updates to Travis per Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 matrix:
   include:
     - name: "Python 3.7.1 on Xenial Linux"
-      language: python  
+      language: python
       python: 3.7           # this works for Linux but is ignored on macOS or Windows
       dist: xenial          # required for Python >= 3.7
       sudo: true
@@ -25,12 +25,12 @@ matrix:
         - pip install -r requirements-dev.txt
       script: python -m pytest tests --cov=solcx
       after_success: python -m coveralls
-    - name: "Python 3.7.3 on Windows"
+    - name: "Python 3.7.4 on Windows"
       os: windows           # Windows 10.0.17134 N/A Build 17134
       language: shell       # 'language: python' is an error on Travis CI Windows
       # python: 3.7         # 'python:' is ignored on Travis CI Windows
       install:
-        - choco install python  # this install takes at least 1 min 30 sec
+        - choco install python --version=3.7.4  # this install takes at least 1 min 30 sec
         - python -m pip install --upgrade pip
         - pip3 install -r requirements-dev.txt
       env: PATH=/c/Python37:/c/Python37/Scripts:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,18 @@
 # Based on https://github.com/cclauss/Travis-CI-Python-on-three-OSes
 matrix:
   include:
+    - name: "Python 3.8.0 on Xenial Linux"
+      language: python
+      python: 3.8
+      dist: xenial
+      sudo: true
+      install:
+        - sudo add-apt-repository -y ppa:ethereum/ethereum
+        - sudo apt-get update
+        - sudo apt-get install -y solc
+        - pip install -r requirements-dev.txt
+      script: python -m pytest tests --cov=solcx
+      after_success: python -m coveralls
     - name: "Python 3.7.1 on Xenial Linux"
       language: python
       python: 3.7           # this works for Linux but is ignored on macOS or Windows
@@ -12,7 +24,10 @@ matrix:
         - sudo apt-get install -y solc
         - pip install -r requirements-dev.txt
         - pip install flake8
-      script: flake8 solcx/ tests/ --max-line-length=100
+      script:
+        - flake8 solcx/ tests/ --max-line-length=100
+        - python -m pytest tests --cov=solcx
+      after_success: python -m coveralls
     - name: "Python 3.6.8 on Xenial Linux"
       language: python
       python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,16 @@
 # Based on https://github.com/cclauss/Travis-CI-Python-on-three-OSes
 matrix:
   include:
+    - name: "Python 3.7.4 on Windows"
+      os: windows           # Windows 10.0.17134 N/A Build 17134
+      language: shell       # 'language: python' is an error on Travis CI Windows
+      install:
+        - choco install python --version=3.7.4
+        - python -m pip install --upgrade pip
+        - pip3 install -r requirements-dev.txt
+      env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
+      script: python -m pytest tests --cov=solcx
+      after_success: python -m coveralls
     - name: "Python 3.8.0 on Xenial Linux"
       language: python
       python: 3.8
@@ -15,8 +25,8 @@ matrix:
       after_success: python -m coveralls
     - name: "Python 3.7.1 on Xenial Linux"
       language: python
-      python: 3.7           # this works for Linux but is ignored on macOS or Windows
-      dist: xenial          # required for Python >= 3.7
+      python: 3.7
+      dist: xenial
       sudo: true
       install:
         - sudo add-apt-repository -y ppa:ethereum/ethereum
@@ -38,17 +48,6 @@ matrix:
         - sudo apt-get update
         - sudo apt-get install -y solc
         - pip install -r requirements-dev.txt
-      script: python -m pytest tests --cov=solcx
-      after_success: python -m coveralls
-    - name: "Python 3.7.4 on Windows"
-      os: windows           # Windows 10.0.17134 N/A Build 17134
-      language: shell       # 'language: python' is an error on Travis CI Windows
-      # python: 3.7         # 'python:' is ignored on Travis CI Windows
-      install:
-        - choco install python --version=3.7.4  # this install takes at least 1 min 30 sec
-        - python -m pip install --upgrade pip
-        - pip3 install -r requirements-dev.txt
-      env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
       script: python -m pytest tests --cov=solcx
       after_success: python -m coveralls
 

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7'
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8'
     ],
 )


### PR DESCRIPTION
### What was wrong / missing?
CI was failing from the release of python 3.8

### How was it fixed / added?
* Modified `.travis.yml` to explicitely install python 3.7 on windows
* Added a new build for python3.8

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/35276322/67157807-5a638580-f36c-11e9-8ee1-a2a287eaeb1a.png)
