### PR TITLE
V0.6.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+0.6.1
+-----
+
+ - Fix compatibility issues with Solidity 0.6.0
+ - When installing on OSX, log a warning instead of raising if dependency installation fails
+ - Ensure old versions are still visible in solcx.get_available_solc_versions
+
 0.6.0
 -----
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Pypi Status](https://img.shields.io/pypi/v/py-solc-x.svg)](https://pypi.org/project/py-solc-x/) [![Build Status](https://img.shields.io/travis/com/iamdefinitelyahuman/py-solc-x.svg)](https://travis-ci.com/iamdefinitelyahuman/py-solc-x) [![Coverage Status](https://coveralls.io/repos/github/iamdefinitelyahuman/py-solc-x/badge.svg?branch=master)](https://coveralls.io/github/iamdefinitelyahuman/py-solc-x?branch=master)
 
-Python wrapper around the `solc` Solidity compiler with `0.5.x` support.
+Python wrapper around the `solc` Solidity compiler with `0.5.x` and `0.6.x` support.
 
 Forked from [py-solc](https://github.com/ethereum/py-solc).
 
@@ -60,7 +60,7 @@ You can also set the version based on the pragma version string. The highest com
 Using solc version 0.5.8
 >>> set_solc_version_pragma('^0.4.20 || >0.5.5 <0.7.0', check_new=True)
 Using solc version 0.5.8
-Newer compatible solc version exists: 0.5.10
+Newer compatible solc version exists: 0.6.0
 ```
 
 To view available and installed versions:
@@ -68,9 +68,9 @@ To view available and installed versions:
 ```python
 >>> from solcx import get_installed_solc_versions, get_available_solc_versions
 >>> get_installed_solc_versions()
-['v0.4.25', 'v0.5.3']
+['v0.4.25', 'v0.5.3', 'v0.6.0']
 >>> get_available_solc_versions()
-['v0.5.10', 'v0.5.9', 'v0.5.8', 'v0.5.7', 'v0.5.6', 'v0.5.5', 'v0.5.4', 'v0.5.3', 'v0.5.2', 'v0.5.1', 'v0.5.0', 'v0.4.25', 'v0.4.24', 'v0.4.23', 'v0.4.22', 'v0.4.21', 'v0.4.20', 'v0.4.19', 'v0.4.18', 'v0.4.17', 'v0.4.16', 'v0.4.15', 'v0.4.14', 'v0.4.13', 'v0.4.12', 'v0.4.11']
+['v0.6.0', 'v0.5.15', 'v0.5.14', 'v0.5.13', 'v0.5.12', 'v0.5.11', 'v0.5.10', 'v0.5.9', 'v0.5.8', 'v0.5.7', 'v0.5.6', 'v0.5.5', 'v0.5.4', 'v0.5.3', 'v0.5.2', 'v0.5.1', 'v0.5.0', 'v0.4.25', 'v0.4.24', 'v0.4.23', 'v0.4.22', 'v0.4.21', 'v0.4.20', 'v0.4.19', 'v0.4.18', 'v0.4.17', 'v0.4.16', 'v0.4.15', 'v0.4.14', 'v0.4.13', 'v0.4.12', 'v0.4.11']
 ```
 
 To install the highest compatible version based on the pragma version string:

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,11 @@ from setuptools import (
 
 setup(
     name='py-solc-x',
-    version='0.6.0',
-    description="""Python wrapper around the solc binary with 0.5.x support""",
+    version='0.6.1',
+    description="""Python wrapper around the solc binary with 0.5.x and 0.6.x support""",
     long_description_markdown_filename='README.md',
     author='Ben Hauser (forked from py-solc by Piper Merriam)',
-    author_email='b.hauser@zerolaw.tech',
+    author_email='ben@hauser.id',
     url='https://github.com/iamdefinitelyahuman/py-solc-x',
     include_package_data=True,
     py_modules=['solcx'],

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -307,10 +307,13 @@ def _install_solc_osx(version, allow_osx):
         tar.extractall(temp_path)
     temp_path = temp_path.joinpath('solidity_{}'.format(version[1:]))
 
-    _check_subprocess_call(
-        ["sh", str(temp_path.joinpath('scripts/install_deps.sh'))],
-        message="Running dependency installation script `install_deps.sh` @ {}".format(temp_path)
-    )
+    try:
+        _check_subprocess_call(
+            ["sh", str(temp_path.joinpath('scripts/install_deps.sh'))],
+            message="Running dependency installation script `install_deps.sh`"
+        )
+    except subprocess.CalledProcessError as e:
+        LOGGER.warning(e, exc_info=True)
 
     original_path = os.getcwd()
     temp_path.joinpath('build').mkdir(exist_ok=True)

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -321,9 +321,11 @@ def _install_solc_osx(version, allow_osx):
         temp_path.joinpath('build/solc/solc').rename(binary_path)
     except subprocess.CalledProcessError as e:
         raise OSError(
-            "{} returned non-zero exit status {}".format(cmd[0], e.returncode) +
-            " while attempting to build solc from the source. This is likely " +
-            "due to a missing or incorrect version of an external dependency."
+            "{} returned non-zero exit status {} while attempting to build solc from the source. "
+            "This is likely due to a missing or incorrect version of an external dependency.\n\n"
+            "You may be able to solve this by installing the specific version using brew: "
+            "https://solidity.readthedocs.io/en/v0.6.0/installing-solidity.html#binary-packages"
+            "".format(cmd[0], e.returncode)
         )
     finally:
         os.chdir(original_path)

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -23,7 +23,7 @@ from .exceptions import (
 )
 
 DOWNLOAD_BASE = "https://github.com/ethereum/solidity/releases/download/{}/{}"
-ALL_RELEASES = "https://api.github.com/repos/ethereum/solidity/releases"
+ALL_RELEASES = "https://api.github.com/repos/ethereum/solidity/releases?per_page=100"
 
 MINIMAL_SOLC_VERSION = "v0.4.11"
 VERSION_REGEX = {

--- a/solcx/wrapper.py
+++ b/solcx/wrapper.py
@@ -104,12 +104,7 @@ def solc_wrapper(solc_binary=None,
     if source_files is not None:
         command.extend(source_files)
 
-    #
     # Output configuration
-    #
-    if ast:
-        command.append('--ast')
-
     if ast_json:
         command.append('--ast-json')
 
@@ -140,15 +135,18 @@ def solc_wrapper(solc_binary=None,
     if devdoc:
         command.append('--devdoc')
 
-    if stdin is not None:
-        # solc seems to expects utf-8 from stdin:
-        # see Scanner class in Solidity source
-        stdin = force_bytes(stdin, 'utf8')
-
     if evm_version:
         command.extend(('--evm-version', evm_version))
 
-    # only supported by 0.4.x versions
+    # unsupported by >=0.6.0
+    if ast:
+        if solc_minor >= 6:
+            raise AttributeError(
+                "solc 0.{}.x does not support the --ast flag".format(solc_minor)
+            )
+        command.append('--ast')
+
+    # unsupported by >=0.5.0
     if clone_bin:
         if solc_minor >= 5:
             raise AttributeError(
@@ -169,6 +167,11 @@ def solc_wrapper(solc_binary=None,
         solc_minor >= 5
     ):
         command.append('-')
+
+    if stdin is not None:
+        # solc seems to expects utf-8 from stdin:
+        # see Scanner class in Solidity source
+        stdin = force_bytes(stdin, 'utf8')
 
     proc = subprocess.Popen(command,
                             stdin=subprocess.PIPE,

--- a/solcx/wrapper.py
+++ b/solcx/wrapper.py
@@ -54,7 +54,8 @@ def solc_wrapper(solc_binary=None,
         solc_binary = get_executable()
 
     command = [solc_binary]
-    solc_minor = Version(solc_binary.rsplit('-v', maxsplit=1)[1]).minor
+
+    solc_minor = Version(solc_binary.rsplit('-v')[-1].split("\\")[0]).minor
 
     if help:
         command.append('--help')

--- a/solcx/wrapper.py
+++ b/solcx/wrapper.py
@@ -2,6 +2,10 @@ from __future__ import absolute_import
 
 import subprocess
 
+from semantic_version import (
+    Version,
+)
+
 from .exceptions import (
     SolcError,
 )
@@ -50,6 +54,7 @@ def solc_wrapper(solc_binary=None,
         solc_binary = get_executable()
 
     command = [solc_binary]
+    solc_minor = Version(solc_binary.rsplit('-v', maxsplit=1)[1]).minor
 
     if help:
         command.append('--help')
@@ -77,7 +82,7 @@ def solc_wrapper(solc_binary=None,
         command.extend(('--output-dir', output_dir))
 
     if combined_json:
-        if "v0.5" in command[0]:
+        if solc_minor >= 5:
             combined_json = combined_json.replace(',clone-bin', '')
         command.extend(('--combined-json', combined_json))
 
@@ -145,19 +150,23 @@ def solc_wrapper(solc_binary=None,
 
     # only supported by 0.4.x versions
     if clone_bin:
-        if "v0.5" in command[0]:
-            raise AttributeError(f"solc 0.5.x does not support the --clone-bin flag")
+        if solc_minor >= 5:
+            raise AttributeError(
+                "solc 0.{}.x does not support the --clone-bin flag".format(solc_minor)
+            )
         command.append('--clone-bin')
 
     if formal:
-        if "v0.5" in command[0]:
-            raise AttributeError(f"solc 0.5.x does not support the --formal flag")
+        if solc_minor >= 5:
+            raise AttributeError(
+                "solc 0.{}.x does not support the --formal flag".format(solc_minor)
+            )
         command.append('--formal')
 
     if (
         not standard_json and
         not source_files and
-        "v0.5" in command[0]
+        solc_minor >= 5
     ):
         command.append('-')
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,7 @@ def foo_source():
     yield """pragma solidity >=0.4.11;
 
 contract Foo {
-    function return13() public returns (uint) {
+    function return13() public returns (uint a) {
         return 13;
     }
 }

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -41,25 +41,28 @@ def test_help(popen):
 
 def test_boolean_kwargs(popen, foo_source):
     kwargs = [
-        'version', 'optimize', 'gas', 'ast', 'ast_json', 'asm', 'asm_json',
-        'opcodes', 'bin', 'bin_runtime', 'abi', 'hashes', 'userdoc', 'devdoc', 'standard_json'
+        'version', 'optimize', 'gas', 'ast_json', 'asm', 'asm_json', 'opcodes',
+        'bin', 'bin_runtime', 'abi', 'hashes', 'userdoc', 'devdoc', 'standard_json'
     ]
     for value in kwargs:
         popen.expect(value)
         solcx.wrapper.solc_wrapper(stdin=foo_source, **{value: True})
 
 
-def test_solc4_only_kwargs(popen):
-    kwargs = ['clone_bin', 'formal']
-    if "0.5" in solcx.get_solc_version_string():
-        for value in kwargs:
-            popen.expect(value)
-            with pytest.raises(AttributeError):
-                solcx.wrapper.solc_wrapper(**{value: True})
-        return
-    for value in kwargs:
+def test_removed_kwargs(popen, foo_source):
+    solc_minor_version = solcx.get_solc_version().minor
+    kwargs = [
+        ('ast', 6),
+        ('clone_bin', 5),
+        ('formal', 5)
+    ]
+    for value, minor in kwargs:
         popen.expect(value)
-        solcx.wrapper.solc_wrapper(**{value: True})
+        if solc_minor_version >= minor:
+            with pytest.raises(AttributeError):
+                solcx.wrapper.solc_wrapper(stdin=foo_source, **{value: True})
+        else:
+            solcx.wrapper.solc_wrapper(stdin=foo_source, **{value: True})
 
 
 def test_value_kwargs(popen, foo_source):


### PR DESCRIPTION
- Fix compatibility issues with Solidity 0.6.0
- When installing on OSX, log a warning instead of raising if dependency installation fails
- Ensure old versions are still visible in `solcx.get_available_solc_versions`

Closes #26 
Closes #27 
