### PR TITLE
Feature/solcx binary path

### DIFF
--- a/solcx/install.py
+++ b/solcx/install.py
@@ -96,7 +96,8 @@ def import_installed_solc(solcx_binary_path=None):
             assert version not in get_installed_solc_versions()
         except Exception:
             continue
-        copy_path = str(get_solc_folder(solcx_binary_path=solcx_binary_path).joinpath("solc-" + version))
+        copy_path = str(get_solc_folder(solcx_binary_path=solcx_binary_path)
+                        .joinpath("solc-" + version))
         shutil.copy(path, copy_path)
         try:
             # confirm that solc still works after being copied
@@ -209,7 +210,8 @@ def _select_pragma_version(pragma_string, version_list):
 
 
 def get_installed_solc_versions(solcx_binary_path=None):
-    return sorted(i.name[5:] for i in get_solc_folder(solcx_binary_path=solcx_binary_path).glob('solc-v*'))
+    return sorted(i.name[5:] for i in get_solc_folder(solcx_binary_path=solcx_binary_path)
+                  .glob('solc-v*'))
 
 
 def install_solc(version, allow_osx=False, show_progress=False, solcx_binary_path=None):
@@ -325,7 +327,8 @@ def _install_solc_windows(version, show_progress, solcx_binary_path=None):
         content = _download_solc(download, show_progress)
         with zipfile.ZipFile(BytesIO(content)) as zf:
             zf.extractall(str(temp_path))
-        install_folder = get_solc_folder(solcx_binary_path=solcx_binary_path).joinpath("solc-" + version)
+        install_folder = get_solc_folder(solcx_binary_path=solcx_binary_path)\
+            .joinpath("solc-" + version)
         temp_path.rename(install_folder)
 
 

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -1,6 +1,7 @@
 """
 Install solc
 """
+import argparse
 from base64 import b64encode
 from io import BytesIO
 import os
@@ -370,10 +371,8 @@ def _install_solc_osx(version, allow_osx, show_progress):
 
 
 if __name__ == "__main__":
-    try:
-        version = sys.argv[1]
-    except IndexError:
-        LOGGER.error("Invocation error.  Should be invoked as `./install_solc.py <release-tag>`")
-        sys.exit(1)
-
-    install_solc(version)
+    argument_parser = argparse.ArgumentParser()
+    argument_parser.add_argument('version')
+    argument_parser.add_argument('--solcx-binary-path', default=None)
+    args = argument_parser.parse_args()
+    install_solc(args.version, args.solcx_binary_path)


### PR DESCRIPTION
### What was wrong / missing?

  * There was an option missing for configuring/overwriting solc binary installation path

### How was it fixed / added?

You can now configure the path either using an environment variable `SOLCX_BINARY_PATH` or by providing an additional parameter to install method.

#### Cute Animal Picture

Sorry, don't have one.
