### PR TITLE
Ensure that setting version w/pragma prepends v

### DIFF
--- a/solcx/install.py
+++ b/solcx/install.py
@@ -139,6 +139,7 @@ def set_solc_version_pragma(pragma_string, silent=False, check_new=False):
             "No compatible solc version installed. "
             + "Use solcx.install_solc_version_pragma('{}') to install.".format(version)
         )
+    version = _check_version(version)
     global solc_version
     solc_version = version
     if not silent:

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -146,7 +146,7 @@ def set_solc_version_pragma(pragma_string, silent=False, check_new=False):
         LOGGER.info("Using solc version {}".format(solc_version))
     if check_new:
         latest = install_solc_pragma(pragma_string, False)
-        if Version(latest) > Version(version):
+        if Version(latest) > Version(version[1:]):
             LOGGER.info("Newer compatible solc version exists: {}".format(latest))
 
 

--- a/tests/test_solc_version.py
+++ b/tests/test_solc_version.py
@@ -43,19 +43,19 @@ def test_get_solc_version_string(all_versions):
 def test_set_solc_version_pragma(pragmapatch):
     set_pragma = functools.partial(solcx.set_solc_version_pragma, check_new=True)
     set_pragma("pragma solidity 0.4.11;")
-    assert solcx.install.solc_version == "0.4.11"
+    assert solcx.install.solc_version == "v0.4.11"
     set_pragma("pragma solidity ^0.4.11;")
-    assert solcx.install.solc_version == "0.4.25"
+    assert solcx.install.solc_version == "v0.4.25"
     set_pragma("pragma solidity >=0.4.0<0.4.25;")
-    assert solcx.install.solc_version == "0.4.11"
+    assert solcx.install.solc_version == "v0.4.11"
     set_pragma("pragma solidity >=0.4.2;")
-    assert solcx.install.solc_version == "1.2.3"
+    assert solcx.install.solc_version == "v1.2.3"
     set_pragma("pragma solidity >=0.4.2<0.5.5;")
-    assert solcx.install.solc_version == "0.5.4"
+    assert solcx.install.solc_version == "v0.5.4"
     set_pragma("pragma solidity ^0.4.2 || 0.5.5;")
-    assert solcx.install.solc_version == "0.4.25"
+    assert solcx.install.solc_version == "v0.4.25"
     set_pragma("pragma solidity ^0.4.2 || >=0.5.4<0.7.0;")
-    assert solcx.install.solc_version == "0.5.7"
+    assert solcx.install.solc_version == "v0.5.7"
     with pytest.raises(SolcNotInstalled):
         set_pragma("pragma solidity ^0.7.1;")
 


### PR DESCRIPTION
### What I did

Ensured that setting version with a pragma prepends a `v` to the version number in the `solc_version` variable.

Related issue: #48 

### How I did it

Ensure that `_check_version` is called before setting the global `solc_version` variable in `set_solc_version_pragma`.

### How to verify it

Call `set_solc_version_pragma` and then call `get_executable` on a system where a Solidity compiler is installed.

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [x] I have included test cases
- [ ] ~~I have updated the documentation (README.md)~~ (bugfix, probably unnecessary?)
- [ ] I have added an entry to the changelog