### PR TITLE
Fix progress bar status code

### DIFF
--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -5,7 +5,7 @@ import sys
 import pytest
 
 import solcx
-from solcx.exceptions import SolcNotInstalled
+from solcx.exceptions import DownloadError, SolcNotInstalled
 
 
 @pytest.fixture(autouse=True)
@@ -45,6 +45,11 @@ def test_install_osx():
         solcx.install_solc("0.4.25")
     solcx.install_solc("0.4.25", allow_osx=True)
     solcx.install_solc("0.5.4")
+
+
+def test_install_unknown_version():
+    with pytest.raises(DownloadError):
+        solcx.install_solc("0.4.99")
 
 
 def test_progress_bar(nosolc):


### PR DESCRIPTION
### What I did
When a download fails and the progress bar is active, correctly identify the failure to avoid the `TypeError: cannot concat bytes to string` exception.

Closes #70 

### How I did it
In `install.py`, check the response status code before streaming the content.

### How to verify it
Run tests.
