### PR TITLE
Mute solc which stderr output

### DIFF
--- a/solcx/install.py
+++ b/solcx/install.py
@@ -77,7 +77,11 @@ def import_installed_solc(solcx_binary_path=None):
 
     # copy active version of solc
     path_list = []
-    which = subprocess.run(["which", "solc"], stdout=subprocess.PIPE).stdout.decode().strip()
+    which = (
+        subprocess.run(["which", "solc"], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+        .stdout.decode()
+        .strip()
+    )
     if which:
         path_list.append(which)
 


### PR DESCRIPTION
### Issue

When a solc binary is not installed on the system, the `which` lookup in the installation routine returns 1 and prints an error message to `stdout`. This message is visible in client applications, even though it is not critical and a solc executable is correctly downloaded and installed.

A sample error message looks like this:
```
which: no solc in (/home/kthxbai/tools/mythx-cli/venv/bin:<more paths>)
```

### What I did

Route the stderr of `which` to /dev/null in the lookup logic for detecting already installed solc versions.

### How to verify it

Run any script that dynamically installs a specified solc version and verify that no error message is shown.

### Checklist

I have not included a changelog entry as the v0.9.0 PR is already open and you might want to include this in the upcoming release by merging this PR into `master` and rebasing into the PR branch.

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have added an entry to the changelog
