### PR TITLE
V0.10.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+0.10.0
+------
+
+ - Check architecture prior to installation, compile when `arm`
+
 0.9.0
 -----
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+comment: false
+coverage:
+  status:
+    project:
+      default:
+        target: 0
+    patch:
+      default:
+        target: 0
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.9.0
+current_version = 0.10.0
 
 [bumpversion:file:setup.py]
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="py-solc-x",
-    version="0.9.0",  # don't change this manually, use bumpversion instead
+    version="0.10.0",  # don't change this manually, use bumpversion instead
     description="Python wrapper around the solc binary with 0.5.x and 0.6.x support",
     long_description_markdown_filename="README.md",
     author="Ben Hauser (forked from py-solc by Piper Merriam)",


### PR DESCRIPTION
### What I did
* add `codecov` config file to avoid comments on PRs and stop failing the build when coverage drops
* update changelog
* bump version to `0.10.0`
