### PR TITLE
Indicate use of stdin with 0.4.x compiler

### DIFF
--- a/solcx/wrapper.py
+++ b/solcx/wrapper.py
@@ -168,7 +168,8 @@ def solc_wrapper(
             )
         command.append("--formal")
 
-    if not standard_json and not source_files and solc_minor >= 5:
+    if not standard_json and not source_files:
+        # indicates that solc should read from stdin
         command.append("-")
 
     if stdin is not None:


### PR DESCRIPTION
### What I did
Always include `-` to indicate use of stdin. This wasn't a requirement for compiling until `0.5.0`, but it turns out it _was_ always needed when combined with `import_remappings`.

Fixes #85 

### How I did it
In `wrapper.py`, remove the check for `and solc_minor >= 5` when deciding if `-` should be added.

### How to verify it
Run the tests.  I've added a new case to verify the behavior of `import_remappings` when combined with `compile_source`.
