### PR TITLE
added aarch64 (arm 64 bit) detection

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+unreleased
+----------
+
+  - Support ARM 64 bit architecture (`aarch64`) #86
+
 0.10.0
 ------
 

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -46,7 +46,7 @@ solc_version = None
 
 
 def _get_arch():
-    if platform.machine().startswith("arm"):
+    if platform.machine().startswith("arm") or platform.machine() == "aarch64":
         return "arm"
     if platform.machine().startswith("x86"):
         return "x86"


### PR DESCRIPTION
Signed-off-by: Matthias Lohr <mail@mlohr.com>

### What I did

Added "support" for ARM 64 bit architectures (by adding detection of `aarch64` as architecture string)

Related issue: 64 bit arm not supported #86

### How to verify it

  * Use it on ARM. Sorry, no CI test available for that due to lack of aarch64 runners.

### Checklist

- [ ] I have confirmed that my PR passes all linting checks
- [ ] ~~I have included test cases~~ (no aarch64 runners)
- [ ] ~~I have updated the documentation (README.md)~~
- [x] I have added an entry to the changelog
