### PR TITLE
ci: add github secret to workflow, remove pytest `-v`

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,6 +5,9 @@ on:
     # run this workflow every Monday at 1PM UTC
     - cron: "* 13 * * 1"
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 name: py-solc-x workflow
 
 jobs:

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,4 +16,4 @@ multi_line_output = 3
 use_parentheses = True
 
 [tool:pytest]
-addopts = -v --cov=solcx --cov-branch --cov-report xml
+addopts = --cov=solcx --cov-branch --cov-report xml


### PR DESCRIPTION
### What I did
* add github token to workflow secrets
* remove `-v` option when running pytest