### PR TITLE
Refactor wrapper and main compile functions

### DIFF
--- a/solcx/exceptions.py
+++ b/solcx/exceptions.py
@@ -8,7 +8,7 @@ class SolcError(Exception):
 
     def __init__(
         self,
-        command: str,
+        command: list,
         return_code: int,
         stdin_data: Optional[str],
         stdout_data: str,

--- a/solcx/main.py
+++ b/solcx/main.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import functools
 import json
 import re
@@ -31,7 +29,13 @@ def get_solc_version() -> Version:
     return Version(strip_zeroes_from_month_and_day(version_string))
 
 
-def _parse_compiler_output(stdoutdata):
+def _get_combined_json_outputs() -> str:
+    help_str = solc_wrapper(help=True)[0].split("\n")
+    combined_json_args = next(i for i in help_str if i.startswith("  --combined-json"))
+    return combined_json_args.split(" ")[-1]
+
+
+def _parse_compiler_output(stdoutdata) -> dict:
     output = json.loads(stdoutdata)
 
     contracts = output.get("contracts", {})
@@ -47,20 +51,9 @@ def _parse_compiler_output(stdoutdata):
     return contracts
 
 
-ALL_OUTPUT_VALUES = (
-    "abi",
-    "asm",
-    "ast",
-    "bin",
-    "bin-runtime",
-    "clone-bin",
-    "devdoc",
-    "opcodes",
-    "userdoc",
-)
-
-
-def compile_source(source, allow_empty=False, output_values=ALL_OUTPUT_VALUES, **kwargs):
+def compile_source(
+    source: str, allow_empty: bool = False, output_values: list = None, **kwargs
+) -> dict:
     if "stdin" in kwargs:
         raise ValueError("The `stdin` keyword is not allowed in the `compile_source` function")
     if "combined_json" in kwargs:
@@ -68,7 +61,11 @@ def compile_source(source, allow_empty=False, output_values=ALL_OUTPUT_VALUES, *
             "The `combined_json` keyword is not allowed in the `compile_source` function"
         )
 
-    combined_json = ",".join(output_values)
+    if output_values is None:
+        combined_json = _get_combined_json_outputs()
+    else:
+        combined_json = ",".join(output_values)
+
     compiler_kwargs = dict(stdin=source, combined_json=combined_json, **kwargs)
 
     stdoutdata, stderrdata, command, proc = solc_wrapper(**compiler_kwargs)
@@ -86,13 +83,19 @@ def compile_source(source, allow_empty=False, output_values=ALL_OUTPUT_VALUES, *
     return contracts
 
 
-def compile_files(source_files, allow_empty=False, output_values=ALL_OUTPUT_VALUES, **kwargs):
+def compile_files(
+    source_files: str, allow_empty: bool = False, output_values: list = None, **kwargs
+) -> dict:
     if "combined_json" in kwargs:
         raise ValueError(
             "The `combined_json` keyword is not allowed in the `compile_files` function"
         )
 
-    combined_json = ",".join(output_values)
+    if output_values is None:
+        combined_json = _get_combined_json_outputs()
+    else:
+        combined_json = ",".join(output_values)
+
     compiler_kwargs = dict(source_files=source_files, combined_json=combined_json, **kwargs)
 
     stdoutdata, stderrdata, command, proc = solc_wrapper(**compiler_kwargs)

--- a/solcx/main.py
+++ b/solcx/main.py
@@ -52,21 +52,46 @@ def _parse_compiler_output(stdoutdata) -> dict:
 
 
 def compile_source(
-    source: str, allow_empty: bool = False, output_values: list = None, **kwargs
+    source: str,
+    output_values: list = None,
+    import_remappings: list = None,
+    base_path: str = None,
+    allow_paths: list = None,
+    output_dir: str = None,
+    overwrite: bool = False,
+    evm_version: str = None,
+    revert_strings: bool = False,
+    metadata_hash: str = None,
+    metadata_literal: bool = False,
+    optimize: bool = False,
+    optimize_runs: int = None,
+    no_optimize_yul: bool = False,
+    yul_optimizations: int = None,
+    allow_empty: bool = False,
 ) -> dict:
-    if "stdin" in kwargs:
-        raise ValueError("The `stdin` keyword is not allowed in the `compile_source` function")
-    if "combined_json" in kwargs:
-        raise ValueError(
-            "The `combined_json` keyword is not allowed in the `compile_source` function"
-        )
 
     if output_values is None:
         combined_json = _get_combined_json_outputs()
     else:
         combined_json = ",".join(output_values)
 
-    compiler_kwargs = dict(stdin=source, combined_json=combined_json, **kwargs)
+    compiler_kwargs = dict(
+        stdin=source,
+        combined_json=combined_json,
+        import_remappings=import_remappings,
+        base_path=base_path,
+        allow_paths=allow_paths,
+        output_dir=output_dir,
+        overwrite=overwrite,
+        evm_version=evm_version,
+        revert_strings=revert_strings,
+        metadata_hash=metadata_hash,
+        metadata_literal=metadata_literal,
+        optimize=optimize,
+        optimize_runs=optimize_runs,
+        no_optimize_yul=no_optimize_yul,
+        yul_optimizations=yul_optimizations,
+    )
 
     stdoutdata, stderrdata, command, proc = solc_wrapper(**compiler_kwargs)
 
@@ -84,19 +109,45 @@ def compile_source(
 
 
 def compile_files(
-    source_files: str, allow_empty: bool = False, output_values: list = None, **kwargs
+    source_files: str,
+    output_values: list = None,
+    import_remappings: list = None,
+    base_path: str = None,
+    allow_paths: list = None,
+    output_dir: str = None,
+    overwrite: bool = False,
+    evm_version: str = None,
+    revert_strings: bool = False,
+    metadata_hash: str = None,
+    metadata_literal: bool = False,
+    optimize: bool = False,
+    optimize_runs: int = None,
+    no_optimize_yul: bool = False,
+    yul_optimizations: int = None,
+    allow_empty: bool = False,
 ) -> dict:
-    if "combined_json" in kwargs:
-        raise ValueError(
-            "The `combined_json` keyword is not allowed in the `compile_files` function"
-        )
-
     if output_values is None:
         combined_json = _get_combined_json_outputs()
     else:
         combined_json = ",".join(output_values)
 
-    compiler_kwargs = dict(source_files=source_files, combined_json=combined_json, **kwargs)
+    compiler_kwargs = dict(
+        source_files=source_files,
+        combined_json=combined_json,
+        import_remappings=import_remappings,
+        base_path=base_path,
+        allow_paths=allow_paths,
+        output_dir=output_dir,
+        overwrite=overwrite,
+        evm_version=evm_version,
+        revert_strings=revert_strings,
+        metadata_hash=metadata_hash,
+        metadata_literal=metadata_literal,
+        optimize=optimize,
+        optimize_runs=optimize_runs,
+        no_optimize_yul=no_optimize_yul,
+        yul_optimizations=yul_optimizations,
+    )
 
     stdoutdata, stderrdata, command, proc = solc_wrapper(**compiler_kwargs)
 
@@ -113,7 +164,14 @@ def compile_files(
     return contracts
 
 
-def compile_standard(input_data, allow_empty=False, **kwargs):
+def compile_standard(
+    input_data,
+    base_path: str = None,
+    allow_paths: list = None,
+    output_dir: str = None,
+    overwrite: bool = False,
+    allow_empty=False,
+):
     if not input_data.get("sources") and not allow_empty:
         raise ContractsNotFound(
             command=None,
@@ -123,9 +181,16 @@ def compile_standard(input_data, allow_empty=False, **kwargs):
             stderr_data=None,
         )
 
-    stdoutdata, stderrdata, command, proc = solc_wrapper(
-        stdin=json.dumps(input_data), standard_json=True, **kwargs
+    compiler_kwargs = dict(
+        stdin=json.dumps(input_data),
+        standard_json=True,
+        base_path=base_path,
+        allow_paths=allow_paths,
+        output_dir=output_dir,
+        overwrite=overwrite,
     )
+
+    stdoutdata, stderrdata, command, proc = solc_wrapper(**compiler_kwargs)
 
     compiler_output = json.loads(stdoutdata)
     if "errors" in compiler_output:

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -6,9 +6,8 @@ import pytest
 
 import solcx
 from solcx.exceptions import ContractsNotFound
-from solcx.main import ALL_OUTPUT_VALUES
 
-# interfaces and compact-format do not return anything
+# these values should work for all compatible solc versions
 combined_json_values = (
     "abi",
     "asm",
@@ -16,7 +15,6 @@ combined_json_values = (
     "bin",
     "bin-runtime",
     "devdoc",
-    "hashes",
     "metadata",
     "opcodes",
     "srcmap",
@@ -33,11 +31,8 @@ def setup(all_versions):
 def _compile_assertions(output, key):
     assert output
     assert key in output
-    for value in ALL_OUTPUT_VALUES:
-        if value == "clone-bin" and solcx.get_solc_version().minor >= 5:
-            assert value not in output[key]
-        else:
-            assert value in output[key]
+    for value in combined_json_values:
+        assert value in output[key]
 
 
 def test_compile_source(foo_source):
@@ -55,8 +50,6 @@ def test_compile_source_empty():
 
 @pytest.mark.parametrize("key", combined_json_values)
 def test_compile_source_output_types(foo_source, key):
-    if key == "hashes" and str(solcx.get_solc_version().truncate()) == "0.4.11":
-        return
     output = solcx.compile_source(foo_source, output_values=[key])
     assert key in output["<stdin>:Foo"]
 
@@ -76,8 +69,6 @@ def test_compile_files_empty():
 
 @pytest.mark.parametrize("key", combined_json_values)
 def test_compile_files_output_types(foo_path, key):
-    if key == "hashes" and str(solcx.get_solc_version().truncate()) == "0.4.11":
-        return
     output = solcx.compile_files([foo_path], output_values=[key])
     assert key in output[f"{foo_path}:Foo"]
 


### PR DESCRIPTION
### What I did
Refactor the wrapper and main compiler functions.

Closes #53 
Closes #80 

### How I did it
* simplify the wrapper logic to accept any keyword argument as a string, int, tuple, list, bool
* use specific kwargs for `compile_source`, `compile_files`, `compile_standard`
* extract output types for `combined_json` by calling `solc --help`

### How to verify it
Run tests.

I haven't yet added new tests - prior to the actual `v1.0.0` release this will be handled, but for now I'm still refactoring and so it feels premature.
