### PR TITLE
Support for Path objects

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,7 +24,7 @@ jobs:
         python-version: 3.6
 
     - name: Install Tox
-      run: pip install tox
+      run: pip install tox wheel
 
     - name: Run Tox
       run: tox -e lint
@@ -42,7 +42,7 @@ jobs:
         python-version: 3.6
 
     - name: Install Tox
-      run: pip install tox
+      run: pip install tox wheel
 
     - name: Run Tox
       run: tox -e py36
@@ -66,7 +66,7 @@ jobs:
         python-version: 3.7
 
     - name: Install Tox
-      run: pip install tox
+      run: pip install tox wheel
 
     - name: Run Tox
       run: tox -e py37
@@ -93,7 +93,7 @@ jobs:
         python-version: 3.8
 
     - name: Install Tox
-      run: pip install tox
+      run: pip install tox wheel
 
     - name: Run Tox
       run: tox -e py38

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,12 @@
 black==19.10b0
 bumpversion==0.5.3
-flake8==3.7.9
+flake8==3.8.3
 isort==4.3.21
-pytest==5.4.1
-pytest-cov==2.8.1
+pytest==5.4.3
+pytest-cov==2.10.0
 semantic_version>=2.8.1,<3
-tox==3.14.6
+tox==3.18.0
 tqdm>=4.41.0,<5.0.0
-twine==1.13.0
+twine==3.2.0
 requests>=2.19.0,<3
+wheel==0.34.2

--- a/solcx/main.py
+++ b/solcx/main.py
@@ -109,7 +109,7 @@ def compile_source(
 
 
 def compile_files(
-    source_files: str,
+    source_files: list,
     output_values: list = None,
     import_remappings: list = None,
     base_path: str = None,

--- a/solcx/wrapper.py
+++ b/solcx/wrapper.py
@@ -1,4 +1,5 @@
 import subprocess
+from pathlib import Path
 from typing import Any
 
 from semantic_version import Version
@@ -26,7 +27,7 @@ def solc_wrapper(
         success_return_code = 0
 
     if source_files is not None:
-        command.extend(source_files)
+        command.extend([str(i) for i in source_files])
 
     if import_remappings is not None:
         command.extend(import_remappings)
@@ -38,7 +39,7 @@ def solc_wrapper(
         key = f"--{key.replace('_', '-')}"
         if value is True:
             command.append(key)
-        elif isinstance(value, (int, str)):
+        elif isinstance(value, (int, str, Path)):
             command.extend([key, str(value)])
         elif isinstance(value, (list, tuple)):
             command.extend([key, ",".join(str(i) for i in value)])

--- a/solcx/wrapper.py
+++ b/solcx/wrapper.py
@@ -8,6 +8,17 @@ from .exceptions import SolcError
 from .install import get_executable
 
 
+def _to_string(key: str, value: Any) -> str:
+    if isinstance(value, (int, str)):
+        return str(value)
+    elif isinstance(value, Path):
+        return value.as_posix()
+    elif isinstance(value, (list, tuple)):
+        return ",".join(_to_string(key, i) for i in value)
+    else:
+        raise TypeError(f"Invalid type for {key}: {type(value)}")
+
+
 def solc_wrapper(
     solc_binary: str = None,
     stdin: str = None,
@@ -27,7 +38,7 @@ def solc_wrapper(
         success_return_code = 0
 
     if source_files is not None:
-        command.extend([str(i) for i in source_files])
+        command.extend([_to_string("source_files", i) for i in source_files])
 
     if import_remappings is not None:
         command.extend(import_remappings)
@@ -39,12 +50,8 @@ def solc_wrapper(
         key = f"--{key.replace('_', '-')}"
         if value is True:
             command.append(key)
-        elif isinstance(value, (int, str, Path)):
-            command.extend([key, str(value)])
-        elif isinstance(value, (list, tuple)):
-            command.extend([key, ",".join(str(i) for i in value)])
         else:
-            raise TypeError(f"Invalid type for {key}: {type(value)}")
+            command.extend([key, _to_string(key, value)])
 
     if "standard_json" not in kwargs and not source_files:
         # indicates that solc should read from stdin

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,7 +107,7 @@ def foo_path(tmp_path, foo_source):
     source = tmp_path.joinpath("Foo.sol")
     with source.open("w") as fp:
         fp.write(foo_source)
-    return source.as_posix()
+    return source
 
 
 @pytest.fixture()
@@ -115,4 +115,4 @@ def bar_path(tmp_path, bar_source):
     source = tmp_path.joinpath("Bar.sol")
     with source.open("w") as fp:
         fp.write(bar_source)
-    return source.as_posix()
+    return source

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -54,11 +54,19 @@ def test_compile_source_output_types(foo_source, key):
     assert key in output["<stdin>:Foo"]
 
 
-def test_compile_files(foo_path):
-    output = solcx.compile_files([foo_path])
-    _compile_assertions(output, f"{foo_path}:Foo")
+def test_compile_files_string(foo_path):
+    output = solcx.compile_files([foo_path.as_posix()])
+    _compile_assertions(output, f"{foo_path.as_posix()}:Foo")
+
+
+def test_compile_files_optimized(foo_path):
     output = solcx.compile_files([foo_path], optimize=True)
-    _compile_assertions(output, f"{foo_path}:Foo")
+    _compile_assertions(output, f"{foo_path.as_posix()}:Foo")
+
+
+def test_compile_files_path_object(foo_path):
+    output = solcx.compile_files([foo_path])
+    _compile_assertions(output, f"{foo_path.as_posix()}:Foo")
 
 
 def test_compile_files_empty():
@@ -70,18 +78,18 @@ def test_compile_files_empty():
 @pytest.mark.parametrize("key", combined_json_values)
 def test_compile_files_output_types(foo_path, key):
     output = solcx.compile_files([foo_path], output_values=[key])
-    assert key in output[f"{foo_path}:Foo"]
+    assert key in output[f"{foo_path.as_posix()}:Foo"]
 
 
 def test_compile_source_import_remapping(foo_path, bar_source):
     path = Path(foo_path).parent.as_posix()
     output = solcx.compile_source(bar_source, import_remappings=[f"contracts={path}"])
 
-    assert set(output) == {f"{foo_path}:Foo", "<stdin>:Bar"}
+    assert set(output) == {f"{foo_path.as_posix()}:Foo", "<stdin>:Bar"}
 
 
 def test_compile_files_import_remapping(foo_path, bar_path):
     path = Path(bar_path).parent.as_posix()
     output = solcx.compile_files([bar_path], import_remappings=[f"contracts={path}"])
 
-    assert set(output) == {f"{bar_path}:Bar", f"{foo_path}:Foo"}
+    assert set(output) == {f"{bar_path.as_posix()}:Bar", f"{foo_path.as_posix()}:Foo"}

--- a/tests/test_compile_standard.py
+++ b/tests/test_compile_standard.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python3
 
-from pathlib import Path
-
 import pytest
 
 import solcx
@@ -47,8 +45,8 @@ def test_compile_standard_with_dependency(input_json, foo_source, bar_source):
 
 
 def test_compile_standard_with_file_paths(input_json, foo_path):
-    input_json["sources"] = {"contracts/Foo.sol": {"urls": [foo_path]}}
-    result = solcx.compile_standard(input_json, allow_paths=Path(foo_path).parent.as_posix())
+    input_json["sources"] = {"contracts/Foo.sol": {"urls": [str(foo_path)]}}
+    result = solcx.compile_standard(input_json, allow_paths=[foo_path.parent])
 
     _compile_assertions(result, "Foo")
 


### PR DESCRIPTION
### What I did
Add support for `Path` objects as compiler inputs.

Closes #55
Closes #65 

### How I did it
Added the `_to_string` private function within the wrapper.  `Path` objects are converted via `.as_posix()` - through a lot of experimentation, it seems this is the only way to get consistent path outputs on Windows across all solc versions.  Later versions of solc will always convert windows paths to the posix-style, whereas earlier versions simply return it in the same format it's received in.

### How to verify it
Run tests.  This could (and will) be tested better before merging to master.

