### PR TITLE
Expand version / binary options in main compile methods

### DIFF
--- a/solcx/install.py
+++ b/solcx/install.py
@@ -75,7 +75,7 @@ def _convert_and_validate_version(version: Union[str, Version]) -> Version:
     return version
 
 
-def get_solc_folder(solcx_binary_path: Optional[str] = None) -> Path:
+def get_solc_folder(solcx_binary_path: Union[Path, str] = None) -> Path:
     if os.getenv(SOLCX_BINARY_PATH_VARIABLE):
         return Path(os.environ[SOLCX_BINARY_PATH_VARIABLE])
     elif solcx_binary_path is not None:
@@ -92,7 +92,7 @@ def _get_import_version(path: str) -> Version:
     return Version.coerce(stdout_data)
 
 
-def import_installed_solc(solcx_binary_path: Optional[str] = None) -> None:
+def import_installed_solc(solcx_binary_path: Union[Path, str] = None) -> None:
     platform = _get_platform()
     if platform == "win32":
         return
@@ -105,7 +105,7 @@ def import_installed_solc(solcx_binary_path: Optional[str] = None) -> None:
         .strip()
     )
     if which:
-        path_list.append(which)
+        path_list.append(Path(which))
 
     # on OSX, also copy all versions of solc from cellar
     if platform == "darwin":
@@ -127,7 +127,7 @@ def import_installed_solc(solcx_binary_path: Optional[str] = None) -> None:
 
 
 def get_executable(
-    version: Union[str, Version] = None, solcx_binary_path: Optional[str] = None
+    version: Union[str, Version] = None, solcx_binary_path: Union[Path, str] = None
 ) -> Path:
     if not version:
         version = solc_version
@@ -150,7 +150,7 @@ def get_executable(
 
 
 def set_solc_version(
-    version: Union[str, Version], silent: bool = False, solcx_binary_path: Optional[str] = None
+    version: Union[str, Version], silent: bool = False, solcx_binary_path: Union[Path, str] = None
 ) -> None:
     version = _convert_and_validate_version(version)
     get_executable(version, solcx_binary_path)
@@ -182,7 +182,7 @@ def install_solc_pragma(
     pragma_string: str,
     install: bool = True,
     show_progress: bool = False,
-    solcx_binary_path: Optional[str] = None,
+    solcx_binary_path: Union[Path, str] = None,
 ) -> Version:
     version = _select_pragma_version(pragma_string, get_available_solc_versions())
     if not version:
@@ -238,7 +238,7 @@ def _select_pragma_version(pragma_string: str, version_list: List[Version]) -> O
     return version
 
 
-def get_installed_solc_versions(solcx_binary_path: Optional[str] = None) -> List[Version]:
+def get_installed_solc_versions(solcx_binary_path: Union[Path, str] = None) -> List[Version]:
     install_path = get_solc_folder(solcx_binary_path)
     return sorted([Version(i.name[6:]) for i in install_path.glob("solc-v*")], reverse=True)
 
@@ -297,7 +297,9 @@ def _chmod_plus_x(executable_path):
     executable_path.chmod(executable_path.stat().st_mode | stat.S_IEXEC)
 
 
-def _check_for_installed_version(version: Version, solcx_binary_path: Optional[str] = None) -> bool:
+def _check_for_installed_version(
+    version: Version, solcx_binary_path: Union[Path, str] = None
+) -> bool:
     path = get_solc_folder(solcx_binary_path).joinpath(f"solc-v{version}")
     return path.exists()
 
@@ -337,7 +339,7 @@ def _download_solc(url, show_progress):
 
 
 def _install_solc_linux(
-    version: Version, show_progress: bool, solcx_binary_path: Optional[str]
+    version: Version, show_progress: bool, solcx_binary_path: Union[Path, str]
 ) -> None:
     download = DOWNLOAD_BASE.format(version, "solc-static-linux")
     install_path = get_solc_folder(solcx_binary_path).joinpath(f"solc-v{version}")
@@ -350,7 +352,7 @@ def _install_solc_linux(
 
 
 def _install_solc_windows(
-    version: Version, show_progress: bool, solcx_binary_path: Optional[str]
+    version: Version, show_progress: bool, solcx_binary_path: Union[Path, str]
 ) -> None:
     download = DOWNLOAD_BASE.format(version, "solidity-windows.zip")
     install_path = get_solc_folder(solcx_binary_path).joinpath(f"solc-v{version}")
@@ -364,13 +366,13 @@ def _install_solc_windows(
 
 
 def _install_solc_arm(
-    version: Version, show_progress: bool, solcx_binary_path: Optional[str]
+    version: Version, show_progress: bool, solcx_binary_path: Union[Path, str]
 ) -> None:
     _compile_solc(version, show_progress, solcx_binary_path)
 
 
 def _install_solc_osx(
-    version: Version, allow_osx: bool, show_progress: bool, solcx_binary_path: Optional[str]
+    version: Version, allow_osx: bool, show_progress: bool, solcx_binary_path: Union[Path, str]
 ) -> None:
     if version < Version("0.5.0") and not allow_osx:
         raise ValueError(
@@ -383,7 +385,9 @@ def _install_solc_osx(
         _compile_solc(version, show_progress, solcx_binary_path)
 
 
-def _compile_solc(version: Version, show_progress: bool, solcx_binary_path: Optional[str]) -> None:
+def _compile_solc(
+    version: Version, show_progress: bool, solcx_binary_path: Union[Path, str]
+) -> None:
     temp_path = _get_temp_folder()
     download = DOWNLOAD_BASE.format(version, f"solidity_{version}.tar.gz")
     install_path = get_solc_folder(solcx_binary_path).joinpath(f"solc-v{version}")

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -128,7 +128,7 @@ def import_installed_solc(solcx_binary_path: Optional[str] = None) -> None:
 
 def get_executable(
     version: Union[str, Version] = None, solcx_binary_path: Optional[str] = None
-) -> str:
+) -> Path:
     if not version:
         version = solc_version
     else:
@@ -146,7 +146,7 @@ def get_executable(
             f"solc {version} has not been installed."
             f" Use solcx.install_solc('{version}') to install."
         )
-    return str(solc_bin)
+    return solc_bin
 
 
 def set_solc_version(
@@ -273,7 +273,7 @@ def install_solc(
             _install_solc_windows(version, show_progress, solcx_binary_path)
         binary_path = get_executable(version, solcx_binary_path)
         _check_subprocess_call(
-            [binary_path, "--version"],
+            [str(binary_path), "--version"],
             message=f"Checking installed executable version at: {binary_path}",
         )
         if not solc_version:

--- a/solcx/main.py
+++ b/solcx/main.py
@@ -1,6 +1,4 @@
-import functools
 import json
-import re
 from pathlib import Path
 from typing import Union
 
@@ -8,28 +6,12 @@ from semantic_version import Version
 
 from .exceptions import ContractsNotFound, SolcError
 from .install import get_executable
-from .wrapper import solc_wrapper
-
-VERSION_DEV_DATE_MANGLER_RE = re.compile(r"(\d{4})\.0?(\d{1,2})\.0?(\d{1,2})")
-strip_zeroes_from_month_and_day = functools.partial(
-    VERSION_DEV_DATE_MANGLER_RE.sub, r"\g<1>.\g<2>.\g<3>"
-)
+from .wrapper import _get_solc_version, solc_wrapper
 
 
 def get_solc_version() -> Version:
-    stdoutdata, stderrdata, command, proc = solc_wrapper(version=True)
-    if "Version: " not in stdoutdata:
-        raise SolcError(
-            command=command,
-            return_code=proc.returncode,
-            stdin_data=None,
-            stdout_data=stdoutdata,
-            stderr_data=stderrdata,
-            message="Unable to extract version string from command output",
-        )
-    version_string = stdoutdata.split("Version: ", maxsplit=1)[1]
-    version_string = version_string.replace("++", "pp").strip()
-    return Version(strip_zeroes_from_month_and_day(version_string))
+    solc_binary = get_executable()
+    return _get_solc_version(solc_binary)
 
 
 def _get_combined_json_outputs() -> str:

--- a/solcx/wrapper.py
+++ b/solcx/wrapper.py
@@ -1,6 +1,6 @@
 import subprocess
 from pathlib import Path
-from typing import Any
+from typing import Any, Union
 
 from semantic_version import Version
 
@@ -20,17 +20,19 @@ def _to_string(key: str, value: Any) -> str:
 
 
 def solc_wrapper(
-    solc_binary: str = None,
+    solc_binary: Union[Path, str] = None,
     stdin: str = None,
     source_files: list = None,
     import_remappings: list = None,
     success_return_code: int = None,
     **kwargs: Any,
 ):
-    if solc_binary is None:
+    if solc_binary:
+        solc_binary = Path(solc_binary)
+    else:
         solc_binary = get_executable()
 
-    command = [solc_binary]
+    command = [solc_binary.as_posix()]
 
     if "help" in kwargs:
         success_return_code = 1
@@ -71,7 +73,7 @@ def solc_wrapper(
     stdoutdata, stderrdata = proc.communicate(stdin)
 
     if proc.returncode != success_return_code:
-        solc_version = Version(solc_binary.rsplit("-v")[-1].split("\\")[0])
+        solc_version = Version(str(solc_binary).rsplit("-v")[-1].split("\\")[0])
         if stderrdata.startswith("unrecognised option"):
             # unrecognised option '<FLAG>'
             flag = stderrdata.split("'")[1]

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -14,6 +14,8 @@ class PopenPatch:
         self.args = []
 
     def __call__(self, cmd, **kwargs):
+        if cmd[1] == "--version":
+            return self.proc(cmd, **kwargs)
         assert cmd[0] == solcx.install.get_executable()
         for i in self.args:
             assert i in cmd


### PR DESCRIPTION
### What I did
* Allow setting `solc_binary` or `solc_version` when calling the main compilation functions. Closes #76 
* Refactor how the active solc version is determined
* More use of `Path` over string

### How to verify it
Run tests. Will add new tests prior to merge to master.