### PR TITLE
Refactor install

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -81,8 +81,9 @@ jobs:
   py38:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v1

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,6 @@ max-line-length = 100
 ignore = E203,W503
 
 [mypy]
-disallow_untyped_defs = True
 ignore_missing_imports = True
 follow_imports = silent
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,8 @@ current_version = 0.10.1
 [flake8]
 max-line-length = 100
 ignore = E203,W503
+per-file-ignores =
+	*/__init__.py: F401
 
 [mypy]
 ignore_missing_imports = True

--- a/solcx/__init__.py
+++ b/solcx/__init__.py
@@ -1,6 +1,4 @@
-from __future__ import absolute_import
-
-from .install import (  # noqa: F401
+from solcx.install import (
     get_available_solc_versions,
     get_installed_solc_versions,
     get_solcx_install_folder,
@@ -10,13 +8,7 @@ from .install import (  # noqa: F401
     set_solc_version,
     set_solc_version_pragma,
 )
-from .main import (  # noqa: F401
-    compile_files,
-    compile_source,
-    compile_standard,
-    get_solc_version,
-    link_code,
-)
+from solcx.main import compile_files, compile_source, compile_standard, get_solc_version, link_code
 
 # check for installed version of solc
 import_installed_solc()

--- a/solcx/__init__.py
+++ b/solcx/__init__.py
@@ -10,10 +10,3 @@ from solcx.install import (
     set_solc_version_pragma,
 )
 from solcx.main import compile_files, compile_source, compile_standard, get_solc_version, link_code
-
-# check for installed version of solc
-import_installed_solc()
-
-# default to latest version
-if get_installed_solc_versions():
-    set_solc_version(get_installed_solc_versions()[-1], silent=True)

--- a/solcx/__init__.py
+++ b/solcx/__init__.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from .install import (  # noqa: F401
     get_available_solc_versions,
     get_installed_solc_versions,
-    get_solc_folder,
+    get_solcx_install_folder,
     import_installed_solc,
     install_solc,
     install_solc_pragma,

--- a/solcx/__init__.py
+++ b/solcx/__init__.py
@@ -1,4 +1,5 @@
 from solcx.install import (
+    compile_solc,
     get_available_solc_versions,
     get_installed_solc_versions,
     get_solcx_install_folder,

--- a/solcx/exceptions.py
+++ b/solcx/exceptions.py
@@ -49,3 +49,7 @@ class SolcNotInstalled(Exception):
 
 class DownloadError(Exception):
     pass
+
+
+class UnexpectedVersionWarning(Warning):
+    pass

--- a/solcx/exceptions.py
+++ b/solcx/exceptions.py
@@ -39,6 +39,10 @@ class ContractsNotFound(SolcError):
     message = "No contracts found during compilation"
 
 
+class SolcInstallationError(Exception):
+    pass
+
+
 class SolcNotInstalled(Exception):
     pass
 

--- a/solcx/exceptions.py
+++ b/solcx/exceptions.py
@@ -43,6 +43,10 @@ class SolcInstallationError(Exception):
     pass
 
 
+class UnexpectedVersionError(Exception):
+    pass
+
+
 class SolcNotInstalled(Exception):
     pass
 

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -313,13 +313,18 @@ def compile_solc(
                 subprocess.check_call(cmd, stderr=subprocess.DEVNULL)
             temp_path.joinpath("build/solc/solc").rename(install_path)
         except subprocess.CalledProcessError as exc:
-            raise SolcInstallationError(
+            err_msg = (
                 f"{cmd[0]} returned non-zero exit status {exc.returncode}"
                 " while attempting to build solc from the source.\n"
-                "This is likely due to a missing or incorrect version of a build dependency.\n\n"
-                "For suggested installation options: "
-                "https://github.com/iamdefinitelyahuman/py-solc-x/wiki/Installing-Solidity-on-OSX"
+                "This is likely due to a missing or incorrect version of a build dependency."
             )
+            if _get_os_name() == "darwin":
+                err_msg = (
+                    f"{err_msg}\n\nFor suggested installation options: "
+                    "https://github.com/iamdefinitelyahuman/py-solc-x/wiki/Installing-Solidity-on-OSX"  # noqa: E501
+                )
+            raise SolcInstallationError(err_msg)
+
         finally:
             os.chdir(original_path)
 

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -292,10 +292,6 @@ def _check_subprocess_call(
     )
 
 
-def _chmod_plus_x(executable_path: Path) -> None:
-    executable_path.chmod(executable_path.stat().st_mode | stat.S_IEXEC)
-
-
 def _check_for_installed_version(
     version: Version, solcx_binary_path: Union[Path, str] = None
 ) -> bool:
@@ -347,7 +343,8 @@ def _install_solc_linux(
     content = _download_solc(download, show_progress)
     with open(install_path, "wb") as fp:
         fp.write(content)
-    _chmod_plus_x(install_path)
+
+    install_path.chmod(install_path.stat().st_mode | stat.S_IEXEC)
 
 
 def _install_solc_windows(
@@ -425,7 +422,7 @@ def _compile_solc(
     finally:
         os.chdir(original_path)
 
-    _chmod_plus_x(install_path)
+    install_path.chmod(install_path.stat().st_mode | stat.S_IEXEC)
 
 
 if __name__ == "__main__":

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -152,9 +152,9 @@ def set_solc_version(
 
 def set_solc_version_pragma(
     pragma_string: str, silent: bool = False, check_new: bool = False
-) -> None:
+) -> Version:
     version = _select_pragma_version(pragma_string, get_installed_solc_versions())
-    if not version:
+    if version is None:
         raise SolcNotInstalled(
             f"No compatible solc version installed."
             f" Use solcx.install_solc_version_pragma('{version}') to install."
@@ -164,6 +164,8 @@ def set_solc_version_pragma(
         latest = install_solc_pragma(pragma_string, False)
         if latest > version:
             LOGGER.info(f"Newer compatible solc version exists: {latest}")
+
+    return version
 
 
 def install_solc_pragma(
@@ -177,6 +179,7 @@ def install_solc_pragma(
         raise ValueError("Compatible solc version does not exist")
     if install:
         install_solc(version, show_progress=show_progress, solcx_binary_path=solcx_binary_path)
+
     return version
 
 

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -76,7 +76,7 @@ def _convert_and_validate_version(version: Union[str, Version]) -> Version:
     return version
 
 
-def get_solc_folder(solcx_binary_path: Union[Path, str] = None) -> Path:
+def get_solcx_install_folder(solcx_binary_path: Union[Path, str] = None) -> Path:
     if os.getenv(SOLCX_BINARY_PATH_VARIABLE):
         return Path(os.environ[SOLCX_BINARY_PATH_VARIABLE])
     elif solcx_binary_path is not None:
@@ -112,7 +112,7 @@ def import_installed_solc(solcx_binary_path: Union[Path, str] = None) -> None:
             assert version not in get_installed_solc_versions()
         except Exception:
             continue
-        copy_path = str(get_solc_folder(solcx_binary_path).joinpath(f"solc-v{version}"))
+        copy_path = str(get_solcx_install_folder(solcx_binary_path).joinpath(f"solc-v{version}"))
         shutil.copy(path, copy_path)
         try:
             # confirm that solc still works after being copied
@@ -133,7 +133,7 @@ def get_executable(
             "Solc is not installed. Call solcx.get_available_solc_versions()"
             " to view for available versions and solcx.install_solc() to install."
         )
-    solc_bin = get_solc_folder(solcx_binary_path).joinpath(f"solc-v{version}")
+    solc_bin = get_solcx_install_folder(solcx_binary_path).joinpath(f"solc-v{version}")
     if sys.platform == "win32":
         solc_bin = solc_bin.joinpath("solc.exe")
     if not solc_bin.exists():
@@ -236,7 +236,7 @@ def _select_pragma_version(pragma_string: str, version_list: List[Version]) -> O
 
 
 def get_installed_solc_versions(solcx_binary_path: Union[Path, str] = None) -> List[Version]:
-    install_path = get_solc_folder(solcx_binary_path)
+    install_path = get_solcx_install_folder(solcx_binary_path)
     return sorted([Version(i.name[6:]) for i in install_path.glob("solc-v*")], reverse=True)
 
 
@@ -256,7 +256,7 @@ def install_solc(
 
     try:
         if _check_for_installed_version(version, solcx_binary_path):
-            path = get_solc_folder(solcx_binary_path).joinpath(f"solc-v{version}")
+            path = get_solcx_install_folder(solcx_binary_path).joinpath(f"solc-v{version}")
             LOGGER.info(f"solc {version} already installed at: {path}")
             return
 
@@ -299,7 +299,7 @@ def _chmod_plus_x(executable_path: Path) -> None:
 def _check_for_installed_version(
     version: Version, solcx_binary_path: Union[Path, str] = None
 ) -> bool:
-    path = get_solc_folder(solcx_binary_path).joinpath(f"solc-v{version}")
+    path = get_solcx_install_folder(solcx_binary_path).joinpath(f"solc-v{version}")
     return path.exists()
 
 
@@ -341,7 +341,7 @@ def _install_solc_linux(
     version: Version, show_progress: bool, solcx_binary_path: Union[Path, str, None]
 ) -> None:
     download = DOWNLOAD_BASE.format(version, "solc-static-linux")
-    install_path = get_solc_folder(solcx_binary_path).joinpath(f"solc-v{version}")
+    install_path = get_solcx_install_folder(solcx_binary_path).joinpath(f"solc-v{version}")
 
     LOGGER.info(f"Downloading solc {version} from {download}")
     content = _download_solc(download, show_progress)
@@ -354,7 +354,7 @@ def _install_solc_windows(
     version: Version, show_progress: bool, solcx_binary_path: Union[Path, str, None]
 ) -> None:
     download = DOWNLOAD_BASE.format(version, "solidity-windows.zip")
-    install_path = get_solc_folder(solcx_binary_path).joinpath(f"solc-v{version}")
+    install_path = get_solcx_install_folder(solcx_binary_path).joinpath(f"solc-v{version}")
 
     temp_path = _get_temp_folder()
     content = _download_solc(download, show_progress)
@@ -392,7 +392,7 @@ def _compile_solc(
 ) -> None:
     temp_path = _get_temp_folder()
     download = DOWNLOAD_BASE.format(version, f"solidity_{version}.tar.gz")
-    install_path = get_solc_folder(solcx_binary_path).joinpath(f"solc-v{version}")
+    install_path = get_solcx_install_folder(solcx_binary_path).joinpath(f"solc-v{version}")
 
     content = _download_solc(download, show_progress)
     with tarfile.open(fileobj=BytesIO(content)) as tar:

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -242,7 +242,6 @@ def get_installed_solc_versions(solcx_binary_path: Union[Path, str] = None) -> L
 
 def install_solc(
     version: Union[str, Version],
-    allow_osx: bool = False,
     show_progress: bool = False,
     solcx_binary_path: Union[Path, str] = None,
 ) -> None:
@@ -265,7 +264,7 @@ def install_solc(
         elif platform == "linux":
             _install_solc_linux(version, show_progress, solcx_binary_path)
         elif platform == "darwin":
-            _install_solc_osx(version, allow_osx, show_progress, solcx_binary_path)
+            _install_solc_osx(version, show_progress, solcx_binary_path)
         elif platform == "win32":
             _install_solc_windows(version, show_progress, solcx_binary_path)
 
@@ -364,20 +363,9 @@ def _install_solc_arm(
 
 
 def _install_solc_osx(
-    version: Version,
-    allow_osx: bool,
-    show_progress: bool,
-    solcx_binary_path: Union[Path, str, None],
+    version: Version, show_progress: bool, solcx_binary_path: Union[Path, str, None]
 ) -> None:
-    if version < Version("0.5.0") and not allow_osx:
-        raise ValueError(
-            "Installing solc {0} on OSX often fails. For suggested installation options:\n"
-            "https://github.com/iamdefinitelyahuman/py-solc-x/wiki/Installing-Solidity-on-OSX\n\n"
-            "To ignore this warning and attempt to install: "
-            "solcx.install_solc('{0}', allow_osx=True)".format(version)
-        )
-    else:
-        _compile_solc(version, show_progress, solcx_binary_path)
+    _compile_solc(version, show_progress, solcx_binary_path)
 
 
 def _compile_solc(
@@ -408,9 +396,9 @@ def _compile_solc(
             LOGGER.info(f"Running `{cmd[0]}`...")
             subprocess.check_call(cmd, stderr=subprocess.DEVNULL)
         temp_path.joinpath("build/solc/solc").rename(install_path)
-    except subprocess.CalledProcessError as e:
-        raise OSError(
-            f"{cmd[0]} returned non-zero exit status {e.returncode}"
+    except subprocess.CalledProcessError as exc:
+        raise SolcInstallationError(
+            f"{cmd[0]} returned non-zero exit status {exc.returncode}"
             " while attempting to build solc from the source.\n"
             "This is likely due to a missing or incorrect version of a build dependency.\n\n"
             "For suggested installation options: "

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -394,7 +394,7 @@ def _compile_solc(
     content = _download_solc(download, show_progress)
     with tarfile.open(fileobj=BytesIO(content)) as tar:
         tar.extractall(temp_path)
-    temp_path = temp_path.joinpath(f"solidity_{version[1:]}")
+    temp_path = temp_path.joinpath(f"solidity_{version}")
 
     try:
         _check_subprocess_call(

--- a/solcx/utils/lock.py
+++ b/solcx/utils/lock.py
@@ -3,7 +3,7 @@ import sys
 import tempfile
 import threading
 from pathlib import Path
-from typing import Dict
+from typing import Any, Dict
 
 if sys.platform == "win32":
     import msvcrt
@@ -34,6 +34,12 @@ class _ProcessLock:
         self._lock = threading.Lock()
         self._lock_path = Path(tempfile.gettempdir()).joinpath(f".solcx-lock-{lock_id}")
         self._lock_file = self._lock_path.open("w")
+
+    def __enter__(self) -> None:
+        self.acquire(True)
+
+    def __exit__(self, *args: Any) -> None:
+        self.release()
 
     def acquire(self, blocking: bool) -> bool:
         raise NotImplementedError("Method not implemented by child class")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,7 +61,7 @@ def all_versions(request):
 # run tests with no installed versions of solc
 @pytest.fixture
 def nosolc():
-    path = solcx.install.get_solc_folder()
+    path = solcx.install.get_solcx_install_folder()
     temp_path = path.parent.joinpath(".temp")
     path.rename(temp_path)
     yield

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -11,17 +11,17 @@ from solcx.exceptions import DownloadError, SolcNotInstalled
 @pytest.fixture(autouse=True)
 def isolation():
     p = sys.platform
-    v = solcx.install.solc_version
+    v = solcx.install._default_solc_binary
     yield
     sys.platform = p
-    solcx.install.solc_version = v
+    solcx.install._default_solc_binary = v
 
 
 def test_not_installed():
     solcx.install.get_executable()
     with pytest.raises(ValueError):
         solcx.install.get_executable("v0.4.0")
-    solcx.install.solc_version = None
+    solcx.install._default_solc_binary = None
     with pytest.raises(SolcNotInstalled):
         solcx.install.get_executable()
 
@@ -34,15 +34,8 @@ def test_unsupported_version():
 
 def test_unknown_platform():
     sys.platform = "potatoOS"
-    with pytest.raises(KeyError):
+    with pytest.raises(OSError):
         solcx.install_solc("0.5.0")
-
-
-@pytest.mark.skipif("sys.platform == 'win32'")
-def test_install_osx():
-    sys.platform = "darwin"
-
-    solcx.install_solc("0.5.4")
 
 
 def test_install_unknown_version():
@@ -52,16 +45,16 @@ def test_install_unknown_version():
 
 @pytest.mark.skipif("'--no-install' in sys.argv")
 def test_progress_bar(nosolc):
-    solcx.install_solc("0.6.0", show_progress=True)
+    solcx.install_solc("0.6.9", show_progress=True)
 
 
 def test_environment_var_path(monkeypatch, tmp_path):
-    install_folder = solcx.get_solc_folder()
+    install_folder = solcx.get_solcx_install_folder()
     monkeypatch.setenv("SOLCX_BINARY_PATH", tmp_path.as_posix())
-    assert solcx.get_solc_folder() != install_folder
+    assert solcx.get_solcx_install_folder() != install_folder
 
     monkeypatch.undo()
-    assert solcx.get_solc_folder() == install_folder
+    assert solcx.get_solcx_install_folder() == install_folder
 
 
 def test_environment_var_versions(monkeypatch, tmp_path):
@@ -75,9 +68,9 @@ def test_environment_var_versions(monkeypatch, tmp_path):
 
 @pytest.mark.skipif("'--no-install' in sys.argv")
 def test_environment_var_install(monkeypatch, tmp_path):
-    assert not tmp_path.joinpath("solc-v0.6.0").exists()
+    assert not tmp_path.joinpath("solc-v0.6.9").exists()
 
     monkeypatch.setenv("SOLCX_BINARY_PATH", tmp_path.as_posix())
 
-    solcx.install_solc("0.6.0")
-    assert tmp_path.joinpath("solc-v0.6.0").exists()
+    solcx.install_solc("0.6.9")
+    assert tmp_path.joinpath("solc-v0.6.9").exists()

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -25,7 +25,7 @@ class ThreadWrap:
 
 
 def test_threadlock(nosolc):
-    threads = [ThreadWrap(solcx.install_solc, "0.5.0") for i in range(4)]
+    threads = [ThreadWrap(solcx.install_solc, "0.6.9") for i in range(4)]
     for t in threads:
         t.join()
 
@@ -33,10 +33,10 @@ def test_threadlock(nosolc):
 def test_processlock(nosolc):
     # have to use a context here to prevent a conflict with tqdm
     ctx = mp.get_context("spawn")
-    threads = [ctx.Process(target=solcx.install_solc, args=("0.5.0",),) for i in range(4)]
+    threads = [ctx.Process(target=solcx.install_solc, args=("0.6.9",)) for i in range(4)]
     for t in threads:
         t.start()
-    solcx.install_solc("0.5.0")
+    solcx.install_solc("0.6.9")
     for t in threads:
         t.join()
         assert t.exitcode == 0

--- a/tests/test_solc_version.py
+++ b/tests/test_solc_version.py
@@ -33,6 +33,7 @@ def pragmapatch(monkeypatch):
             Version("0.6.0"),
         ],
     )
+    monkeypatch.setattr("solcx.install.set_solc_version", lambda *args: None)
 
 
 def test_get_solc_version(all_versions):
@@ -42,20 +43,13 @@ def test_get_solc_version(all_versions):
 
 def test_set_solc_version_pragma(pragmapatch):
     set_pragma = functools.partial(solcx.set_solc_version_pragma, check_new=True)
-    set_pragma("pragma solidity 0.4.11;")
-    assert solcx.install.solc_version == Version("0.4.11")
-    set_pragma("pragma solidity ^0.4.11;")
-    assert solcx.install.solc_version == Version("0.4.25")
-    set_pragma("pragma solidity >=0.4.0<0.4.25;")
-    assert solcx.install.solc_version == Version("0.4.11")
-    set_pragma("pragma solidity >=0.4.2;")
-    assert solcx.install.solc_version == Version("1.2.3")
-    set_pragma("pragma solidity >=0.4.2<0.5.5;")
-    assert solcx.install.solc_version == Version("0.5.4")
-    set_pragma("pragma solidity ^0.4.2 || 0.5.5;")
-    assert solcx.install.solc_version == Version("0.4.25")
-    set_pragma("pragma solidity ^0.4.2 || >=0.5.4<0.7.0;")
-    assert solcx.install.solc_version == Version("0.5.7")
+    assert set_pragma("pragma solidity 0.4.11;") == Version("0.4.11")
+    assert set_pragma("pragma solidity ^0.4.11;") == Version("0.4.25")
+    assert set_pragma("pragma solidity >=0.4.0<0.4.25;") == Version("0.4.11")
+    assert set_pragma("pragma solidity >=0.4.2;") == Version("1.2.3")
+    assert set_pragma("pragma solidity >=0.4.2<0.5.5;") == Version("0.5.4")
+    assert set_pragma("pragma solidity ^0.4.2 || 0.5.5;") == Version("0.4.25")
+    assert set_pragma("pragma solidity ^0.4.2 || >=0.5.4<0.7.0;") == Version("0.5.7")
     with pytest.raises(SolcNotInstalled):
         set_pragma("pragma solidity ^0.7.1;")
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,4 +16,4 @@ commands =
     black --check {toxinidir}/solcx {toxinidir}/tests
     flake8 {toxinidir}/solcx {toxinidir}/tests
     isort --check-only --diff --recursive {toxinidir}/solcx {toxinidir}/tests
-    mypy {toxinidir}/solcx
+    mypy --disallow-untyped-defs {toxinidir}/solcx


### PR DESCRIPTION
### What I did
* rename `get_solc_folder` to `get_solcx_install_folder`
* remove various private methods
* install precompiled OSX binaries (!!)
* separate logic for installing and compiling solc (`compile_solc` is now part of the public API)
* use `where` to find existing installation on windows
