### PR TITLE
Install from solc-bin and separate building from source logic

### DIFF
--- a/docs/version-management.rst
+++ b/docs/version-management.rst
@@ -83,38 +83,38 @@ Setting the Active Version
         Version('0.5.17')
 
 
-Installing Solidity
-===================
-
-Getting Installable Versions
-----------------------------
-
-.. py:function:: solcx.get_available_solc_versions(headers=None, compilable=False)
-
-    Return a list of all ``solc`` versions that can be installed by py-solc-x.
-
-        ``headers`` Dict
-            Headers to include in the request to Github.
-        ``compilable`` bool
-            If ``True``, return a list of versions that can be compiled from source.
-
-    .. code-block:: python
-
-        >>> solcx.get_available_solc_versions()
-        [Version('0.7.0'), Version('0.6.12'), Version('0.6.11'), Version('0.6.10'), Version('0.6.9'), Version('0.6.8'), Version('0.6.7'), Version('0.6.6'), Version('0.6.5'), Version('0.6.4'), Version('0.6.3'), Version('0.6.2'), Version('0.6.1'), Version('0.6.0'), Version('0.5.17'), Version('0.5.16'), Version('0.5.15'), Version('0.5.14'), Version('0.5.13'), Version('0.5.12'), Version('0.5.11'), Version('0.5.10'), Version('0.5.9'), Version('0.5.8'), Version('0.5.7'), Version('0.5.6'), Version('0.5.5'), Version('0.5.4'), Version('0.5.3'), Version('0.5.2'), Version('0.5.1'), Version('0.5.0'), Version('0.4.26'), Version('0.4.25'), Version('0.4.24'), Version('0.4.23'), Version('0.4.22'), Version('0.4.21'), Version('0.4.20'), Version('0.4.19'), Version('0.4.18'), Version('0.4.17'), Version('0.4.16'), Version('0.4.15'), Version('0.4.14'), Version('0.4.13'), Version('0.4.12'), Version('0.4.11')]
-
 Importing Already-Installed Versions
-------------------------------------
+====================================
 
 .. py:function:: solcx.import_installed_solc(solcx_binary_path=None)
 
     Search for and copy installed ``solc`` versions into the local installation folder.
+
+    This function is especially useful on OSX, to access Solidity versions that you have installed from homebrew and where a precompiled binary is not available.
 
     .. code-block:: python
 
         >>> solcx.import_installed_solc()
         [Version('0.7.0'), Version('0.6.12')]
 
+
+Installing Solidity
+===================
+
+py-solc-x downloads and installs precompiled binaries from `solc-bin.ethereum.org <solc-bin.ethereum.org>`_. Different binaries are available depending on your operating system.
+
+Getting Installable Versions
+----------------------------
+
+.. py:function:: solcx.get_installable_solc_versions()
+
+    Return a list of all ``solc`` versions that can be installed by py-solc-x.
+
+
+    .. code-block:: python
+
+        >>> solcx.get_installable_solc_versions()
+        [Version('0.7.0'), Version('0.6.12'), Version('0.6.11'), Version('0.6.10'), Version('0.6.9'), Version('0.6.8'), Version('0.6.7'), Version('0.6.6'), Version('0.6.5'), Version('0.6.4'), Version('0.6.3'), Version('0.6.2'), Version('0.6.1'), Version('0.6.0'), Version('0.5.17'), Version('0.5.16'), Version('0.5.15'), Version('0.5.14'), Version('0.5.13'), Version('0.5.12'), Version('0.5.11'), Version('0.5.10'), Version('0.5.9'), Version('0.5.8'), Version('0.5.7'), Version('0.5.6'), Version('0.5.5'), Version('0.5.4'), Version('0.5.3'), Version('0.5.2'), Version('0.5.1'), Version('0.5.0'), Version('0.4.26'), Version('0.4.25'), Version('0.4.24'), Version('0.4.23'), Version('0.4.22'), Version('0.4.21'), Version('0.4.20'), Version('0.4.19'), Version('0.4.18'), Version('0.4.17'), Version('0.4.16'), Version('0.4.15'), Version('0.4.14'), Version('0.4.13'), Version('0.4.12'), Version('0.4.11')]
 
 Installing Precompiled Binaries
 -------------------------------
@@ -131,18 +131,40 @@ Installing Precompiled Binaries
         ``solcx_binary_path`` Path | str
             User-defined path, used to override the default installation directory.
 
-Buildling from Source
----------------------
+Building from Source
+====================
+
+When a precompiled version of Solidity isn't available for your operating system, you may still install it by building from the source code. Source code is downloaded from `Github <https://github.com/ethereum/solidity/releases>`_.
+
+.. note::
+
+    If you wish to compile from source you must first install the required `solc dependencies <https://solidity.readthedocs.io/en/latest/installing-solidity.html#building-from-source>`_.
+
+
+Getting Compilable Versions
+---------------------------
+
+.. py:function:: solcx.get_compilable_solc_versions(headers=None)
+
+    Return a list of all ``solc`` versions that can be installed by py-solc-x.
+
+        ``headers`` Dict
+            Headers to include in the request to Github.
+
+    .. code-block:: python
+
+        >>> solcx.get_compilable_solc_versions()
+        [Version('0.7.0'), Version('0.6.12'), Version('0.6.11'), Version('0.6.10'), Version('0.6.9'), Version('0.6.8'), Version('0.6.7'), Version('0.6.6'), Version('0.6.5'), Version('0.6.4'), Version('0.6.3'), Version('0.6.2'), Version('0.6.1'), Version('0.6.0'), Version('0.5.17'), Version('0.5.16'), Version('0.5.15'), Version('0.5.14'), Version('0.5.13'), Version('0.5.12'), Version('0.5.11'), Version('0.5.10'), Version('0.5.9'), Version('0.5.8'), Version('0.5.7'), Version('0.5.6'), Version('0.5.5'), Version('0.5.4'), Version('0.5.3'), Version('0.5.2'), Version('0.5.1'), Version('0.5.0'), Version('0.4.26'), Version('0.4.25'), Version('0.4.24'), Version('0.4.23'), Version('0.4.22'), Version('0.4.21'), Version('0.4.20'), Version('0.4.19'), Version('0.4.18'), Version('0.4.17'), Version('0.4.16'), Version('0.4.15'), Version('0.4.14'), Version('0.4.13'), Version('0.4.12'), Version('0.4.11')]
+
+
+Compiling Solidity from Source
+------------------------------
 
 .. py:function:: solcx.compile_solc(version, show_progress=False, solcx_binary_path=None)
 
     Install a version of ``solc`` by downloading and compiling source code.
 
     This function is only available when using Linux or OSX.
-
-    .. note::
-
-        If you wish to compile from source you must first install the required `solc dependencies <https://solidity.readthedocs.io/en/latest/installing-solidity.html#building-from-source>`_.
 
     **Arguments:**
 

--- a/solcx/__init__.py
+++ b/solcx/__init__.py
@@ -1,6 +1,7 @@
 from solcx.install import (
     compile_solc,
-    get_available_solc_versions,
+    get_compilable_solc_versions,
+    get_installable_solc_versions,
     get_installed_solc_versions,
     get_solcx_install_folder,
     import_installed_solc,

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -343,6 +343,9 @@ def get_compilable_solc_versions(headers: Optional[Dict] = None) -> List[Version
     List
         List of Versions objects of installable `solc` versions.
     """
+    if _get_os_name() == "windows":
+        raise OSError("Compiling from source is not supported on Windows systems")
+
     version_list = []
     pattern = "solidity_[0-9].[0-9].[0-9]{1,}.tar.gz"
 

--- a/solcx/install.py
+++ b/solcx/install.py
@@ -435,7 +435,10 @@ def install_solc(
             raise ConnectionError(
                 f"Status {data.status_code} when getting solc versions from solc-bin.ethereum.org"
             )
-        filename = data.json()["releases"][str(version)]
+        try:
+            filename = data.json()["releases"][str(version)]
+        except KeyError:
+            raise SolcInstallationError(f"Solc binary for v{version} is not available for this OS")
 
         if os_name == "linux":
             _install_solc_unix(version, filename, show_progress, solcx_binary_path)

--- a/solcx/wrapper.py
+++ b/solcx/wrapper.py
@@ -1,3 +1,4 @@
+import re
 import subprocess
 from pathlib import Path
 from typing import Any, Dict, List, Tuple, Union
@@ -10,9 +11,10 @@ from solcx.exceptions import SolcError, UnknownOption, UnknownValue
 
 def _get_solc_version(solc_binary: Union[Path, str]) -> Version:
     # private wrapper function to get `solc` version
-    stdout_data = subprocess.check_output([solc_binary, "--version"], encoding="utf8").strip()
-    stdout_data = stdout_data[stdout_data.index("Version: ") + 9 : stdout_data.index("+")]
-    return Version.coerce(stdout_data)
+    stdout_data = subprocess.check_output([solc_binary, "--version"], encoding="utf8")
+    version_str = re.findall(r"(?<=Version: ).*?(?=\+)", stdout_data)[0]
+    version_str = re.sub(r"\.0(?=[1-9])", ".", version_str)
+    return Version.coerce(version_str)
 
 
 def _to_string(key: str, value: Any) -> str:

--- a/tests/install/conftest.py
+++ b/tests/install/conftest.py
@@ -130,7 +130,7 @@ def pragmapatch(monkeypatch):
         ],
     )
     monkeypatch.setattr(
-        "solcx.install.get_available_solc_versions",
+        "solcx.install.get_installable_solc_versions",
         lambda: [
             Version("0.4.11"),
             Version("0.4.24"),

--- a/tests/install/test_install.py
+++ b/tests/install/test_install.py
@@ -3,12 +3,12 @@
 import pytest
 
 import solcx
-from solcx.exceptions import DownloadError
+from solcx.exceptions import SolcInstallationError
 
 
 @pytest.mark.skipif("'--no-install' in sys.argv")
 def test_install_latest():
-    version = solcx.get_available_solc_versions()[0]
+    version = solcx.get_installable_solc_versions()[0]
     assert solcx.install_solc("latest") == version
 
 
@@ -19,7 +19,7 @@ def test_unknown_platform(monkeypatch):
 
 
 def test_install_unknown_version():
-    with pytest.raises(DownloadError):
+    with pytest.raises(SolcInstallationError):
         solcx.install_solc("0.4.99")
 
 


### PR DESCRIPTION
### What I did
Download solc binaries from https://solc-bin.ethereum.org/

Related issue: https://github.com/ethereum/solidity/issues/9226

### How I did it
* `get_available_solc_versions` has been split into `get_installable_solc_versions` and `get_compilable_solc_versions`
* Installation by building from source is now handled by a separate function, `compile_solc`. At this point, Windows is not supported.

### How to verify it
Run tests.
