### PR TITLE
Update solc version detection regex and error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 This project was forked from `py-solc`. View the original changelog [here](https://github.com/ethereum/py-solc/blob/master/CHANGELOG).
 
 ## [Unreleased](https://github.com/iamdefinitelyahuman/py-solc-x)
+- improve `solc` version detection and raise correct error if it fails
 
 ## [1.0.0](https://github.com/iamdefinitelyahuman/py-solc-x/releases/tag/v1.0.0) - 2020-08-26
 ### Added

--- a/solcx/wrapper.py
+++ b/solcx/wrapper.py
@@ -12,8 +12,10 @@ from solcx.exceptions import SolcError, UnknownOption, UnknownValue
 def _get_solc_version(solc_binary: Union[Path, str]) -> Version:
     # private wrapper function to get `solc` version
     stdout_data = subprocess.check_output([solc_binary, "--version"], encoding="utf8")
-    version_str = re.findall(r"(?<=Version: ).*?(?=\+)", stdout_data)[0]
-    version_str = re.sub(r"\.0(?=[1-9])", ".", version_str)
+    try:
+        version_str = re.findall(r"\d+\.\d+\.\d+", stdout_data)[0]
+    except IndexError:
+        raise SolcError("Could not determine the solc binary version")
     return Version.coerce(version_str)
 
 


### PR DESCRIPTION
### What I did
I updated the version regex to a more readable and robust version, which detects the first semantic version in the `solc --version` output.

### How I did it
With my hands and an editor.

### How to verify it
E.g. on `solcx.compile_standard`, pass in a `solc_binary` version and see the identical behaviour. On top, if the output does not contain a match, a `SolcError` is raised instead of an internal, unhandled `IndexError`.

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [ ] I have included test cases *(not needed as already covered)*
- [ ] I have updated the documentation (README.md) *(not needed as already covered)*
- [x] I have added an entry to the changelog
