### PR TITLE
Handle non-standard tags from Github API

### DIFF
--- a/solcx/install.py
+++ b/solcx/install.py
@@ -368,7 +368,12 @@ def get_compilable_solc_versions(headers: Optional[Dict] = None) -> List[Version
         raise ConnectionError(msg)
 
     for release in data.json():
-        version = Version.coerce(release["tag_name"].lstrip("v"))
+        try:
+            version = Version.coerce(release["tag_name"].lstrip("v"))
+        except ValueError:
+            # ignore non-standard releases (e.g. the 0.8.x preview)
+            continue
+
         asset = next((i for i in release["assets"] if re.match(pattern, i["name"])), False)
         if asset:
             version_list.append(version)


### PR DESCRIPTION
### What I did
Handle non-standard versions when querying compilable sources.

This fixes the issue caused by the `preview-0.8.0` solc version.

### How to verify it
Run tests.

#111 is still unresolved, so the expected outcome here is that CI will pass on all jobs _except_ windows.

