### PR TITLE
Fix windows paths

### DIFF
--- a/solcx/install.py
+++ b/solcx/install.py
@@ -458,10 +458,11 @@ def install_solc(
         try:
             _validate_installation(version, solcx_binary_path)
         except SolcInstallationError as exc:
-            exc.args = (
-                f"{exc.args[0]} If this issue persists, you can try to compile from "
-                f"source code using `solcx.compile_solc('{version}')`.",
-            )
+            if os_name != "windows":
+                exc.args = (
+                    f"{exc.args[0]} If this issue persists, you can try to compile from "
+                    f"source code using `solcx.compile_solc('{version}')`.",
+                )
             raise exc
 
     return version

--- a/solcx/wrapper.py
+++ b/solcx/wrapper.py
@@ -11,7 +11,7 @@ from solcx.exceptions import SolcError, UnknownOption, UnknownValue
 
 def _get_solc_version(solc_binary: Union[Path, str]) -> Version:
     # private wrapper function to get `solc` version
-    stdout_data = subprocess.check_output([solc_binary, "--version"], encoding="utf8")
+    stdout_data = subprocess.check_output([str(solc_binary), "--version"], encoding="utf8")
     try:
         version_str = re.findall(r"\d+\.\d+\.\d+", stdout_data)[0]
     except IndexError:
@@ -87,7 +87,7 @@ def solc_wrapper(
         solc_binary = install.get_executable()
 
     solc_version = _get_solc_version(solc_binary)
-    command: List = [solc_binary]
+    command: List = [str(solc_binary)]
 
     if success_return_code is None:
         success_return_code = 1 if "help" in kwargs else 0

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -17,7 +17,7 @@ class PopenPatch:
     def __call__(self, cmd, **kwargs):
         if cmd[1] == "--version":
             return self.proc(cmd, **kwargs)
-        assert cmd[0] == solcx.install.get_executable()
+        assert cmd[0] == str(solcx.install.get_executable())
         for i in self.args:
             assert i in cmd
         return self.proc(cmd, **kwargs)


### PR DESCRIPTION
### What I did
* Convert `Path` objects to strings prior to calling `subprocess`.
* On a failed windows installation, do not suggest attempting to compile from source (it's not supported)

Closes #116 

### How to verify it
Run the test suite.