### PR TITLE
Fix for ABI format in Solidity 0.8.0

### DIFF
--- a/solcx/main.py
+++ b/solcx/main.py
@@ -245,7 +245,7 @@ def _parse_compiler_output(stdoutdata: str) -> Dict:
     sources = output.get("sources", {})
 
     for path_str, data in contracts.items():
-        if "abi" in data:
+        if "abi" in data and isinstance(data["abi"], str):
             data["abi"] = json.loads(data["abi"])
         key = path_str.rsplit(":", maxsplit=1)[0]
         if "AST" in sources.get(key, {}):


### PR DESCRIPTION
### What I did
Fix an issue when decoding the ABI from Solidity 0.8.0

### How I did it
Check if the ABI is a string prior to converting it from JSON.

### How to verify it
Run the tests.
