### PR TITLE
Include commit hash in `get_solc_version`

### DIFF
--- a/docs/version-management.rst
+++ b/docs/version-management.rst
@@ -29,14 +29,20 @@ Getting the Active Version
 
 Use the following methods to check the active ``solc`` version:
 
-.. py:function:: solcx.get_solc_version()
+.. py:function:: solcx.get_solc_version(with_commit_hash=False)
 
     Return the version of the current active ``solc`` binary, as a :py:class:`Version <semantic_version.Version>` object.
+
+    * ``with_commit_hash``: If ``True``, the returned version includes the commit hash
 
     .. code-block:: python
 
         >>> solcx.get_solc_version()
         Version('0.7.0')
+
+        >>> solcx.get_solc_version(True)
+        Version('0.7.0+commit.9e61f92b')
+
 
 .. py:function:: solcx.install.get_executable(version=None, solcx_binary_path=None)
 

--- a/solcx/main.py
+++ b/solcx/main.py
@@ -8,12 +8,15 @@ from solcx import wrapper
 from solcx.exceptions import ContractsNotFound, SolcError
 from solcx.install import get_executable
 
-# from solcx.wrapper import _get_solc_version, solc_wrapper
 
-
-def get_solc_version() -> Version:
+def get_solc_version(with_commit_hash: bool = False) -> Version:
     """
     Get the version of the active `solc` binary.
+
+    Arguments
+    ---------
+    with_commit_hash : bool, optional
+        If True, the commit hash is included within the version
 
     Returns
     -------
@@ -21,7 +24,7 @@ def get_solc_version() -> Version:
         solc version
     """
     solc_binary = get_executable()
-    return wrapper._get_solc_version(solc_binary)
+    return wrapper._get_solc_version(solc_binary, with_commit_hash)
 
 
 def compile_source(

--- a/solcx/wrapper.py
+++ b/solcx/wrapper.py
@@ -9,14 +9,19 @@ from solcx import install
 from solcx.exceptions import SolcError, UnknownOption, UnknownValue
 
 
-def _get_solc_version(solc_binary: Union[Path, str]) -> Version:
+def _get_solc_version(solc_binary: Union[Path, str], with_commit_hash: bool = False) -> Version:
     # private wrapper function to get `solc` version
     stdout_data = subprocess.check_output([str(solc_binary), "--version"], encoding="utf8")
     try:
-        version_str = re.findall(r"\d+\.\d+\.\d+", stdout_data)[0]
+        version_str = re.findall(r"\d+\.\d+\.\d+\+commit.\w+", stdout_data)[0]
     except IndexError:
         raise SolcError("Could not determine the solc binary version")
-    return Version.coerce(version_str)
+
+    version = Version.coerce(version_str)
+    if with_commit_hash:
+        return version
+    else:
+        return version.truncate()
 
 
 def _to_string(key: str, value: Any) -> str:

--- a/solcx/wrapper.py
+++ b/solcx/wrapper.py
@@ -8,13 +8,17 @@ from semantic_version import Version
 from solcx import install
 from solcx.exceptions import SolcError, UnknownOption, UnknownValue
 
+# (major.minor.patch)(nightly)(commit)
+VERSION_REGEX = r"(\d+\.\d+\.\d+)(?:-nightly.\d+.\d+.\d+|)(\+commit.\w+)"
+
 
 def _get_solc_version(solc_binary: Union[Path, str], with_commit_hash: bool = False) -> Version:
     # private wrapper function to get `solc` version
     stdout_data = subprocess.check_output([str(solc_binary), "--version"], encoding="utf8")
     try:
-        version_str = re.findall(r"\d+\.\d+\.\d+\+commit.\w+", stdout_data)[0]
-    except IndexError:
+        match = next(re.finditer(VERSION_REGEX, stdout_data))
+        version_str = "".join(match.groups())
+    except StopIteration:
         raise SolcError("Could not determine the solc binary version")
 
     version = Version.coerce(version_str)

--- a/tests/install/test_solc_version.py
+++ b/tests/install/test_solc_version.py
@@ -32,3 +32,11 @@ def test_install_solc_version_pragma(pragmapatch):
     assert install_pragma("pragma solidity ^0.4.2 || >=0.5.4<0.7.0;") == Version("0.6.0")
     with pytest.raises(UnsupportedVersionError):
         install_pragma("pragma solidity ^0.7.1;")
+
+
+def test_get_solc_version():
+    version = solcx.get_solc_version()
+    version_with_hash = solcx.get_solc_version(with_commit_hash=True)
+
+    assert version != version_with_hash
+    assert version == version_with_hash.truncate()


### PR DESCRIPTION
### What I did
Allow querying the commit hash when calling `get_solc_version`

### How I did it
Added an optional kwarg, `with_commit_hash`.

### How to verify it
Run the tests. I've added a new test case to verify the behaviour.
