### PR TITLE
fix: user warning when solc is not installed

### DIFF
--- a/solcx/install.py
+++ b/solcx/install.py
@@ -181,7 +181,7 @@ def get_executable(
     if not version:
         if not _default_solc_binary:
             raise SolcNotInstalled(
-                "Solc is not installed. Call solcx.get_available_solc_versions()"
+                "Solc is not installed. Call solcx.get_installable_solc_versions()"
                 " to view for available versions and solcx.install_solc() to install."
             )
         return _default_solc_binary


### PR DESCRIPTION
### What I did
Updated the user warning given when solc is not installed so that instead of it saying "Call solcx.get_available_solc_versions() to view for available versions" to "Call solcx.get_installable_solc_versions() to view for available versions" as the previous function doesn't seem to exist anymore.
A minor change but slightly helpful :D

Related issue: # None

### How I did it
After receiving the error, I used dir(solx) after I imported it to see what attributes and functions it had.

### How to verify it
Since I only edited a string that is displayed for the user, I assumed that test cases weren't necessary and neither were verifications.

### Checklist

- [x] I have confirmed that my PR passes all linting checks
- [-] I have included test cases
- [-] I have updated the documentation (README.md)
- [-] I have added an entry to the changelog
